### PR TITLE
Update Node.js version requirement to 22+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Creating API tokens through the Cloudflare dashboard involves navigating nested 
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 22+
 - A Cloudflare **Global API Key** (found under My Profile > API Tokens)
 - Your Cloudflare account email
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated prerequisites to require Node.js 22+ instead of 18+. This aligns the docs with our supported runtime and clarifies the minimum version for local setup.

<sup>Written for commit 3ed3b0fc6730520030506ea0fb6dbc94155162c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

