### PR TITLE
chore: ignore @types/node major bumps beyond v22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
           - "*"
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [">=23.0.0"]
     commit-message:
       prefix: "chore(deps)"
 


### PR DESCRIPTION
## Summary

- Adds a Dependabot `ignore` rule for `@types/node >= 23.0.0`
- Keeps automatic patch/minor updates within the `22.x` range
- Prevents the jump from `22.15.x` to `25.x` that breaks Node 22 type compatibility

## Why

`@types/node` v25 targets Node 25, which introduces type-level breaking changes for a project targeting Node 22. Pinning to `22.x` keeps types aligned with the runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Dependabot to ignore `@types/node` versions >=23.0.0 so we stay on Node 22-compatible types. This prevents jumps to v25 and keeps minor/patch updates within `22.x`.

<sup>Written for commit ec8de9fda2b007fe2b29ab2812d4d9e0a3c97c1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

