### PR TITLE
feat: replace Global API Key with Create Additional Tokens Key

### DIFF
--- a/.changeset/happy-masks-design.md
+++ b/.changeset/happy-masks-design.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": minor
+---
+
+Replace Global API Key with Create Additional Tokens Key

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 CF_EMAIL=your_cloudflare_account_email          # The email you use to login to Cloudflare
-CF_API_TOKEN=your_cloudflare_global_api_key     # Located at the bottom of https://dash.cloudflare.com/profile/api-tokens
+CF_API_TOKEN=your_cloudflare_create_additional_tokens_key     # Create at https://dash.cloudflare.com/profile/api-tokens > Create Token > Create Additional Tokens

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-CF_EMAIL=your_cloudflare_account_email          # The email you use to login to Cloudflare
-CF_API_TOKEN=your_cloudflare_create_additional_tokens_key     # Create at https://dash.cloudflare.com/profile/api-tokens > Create Token > Create Additional Tokens
+CF_API_TOKEN="your_cloudflare_create_additional_tokens_key"  # Create at https://dash.cloudflare.com/profile/api-tokens > Create Token > Create Additional Tokens
+CF_EMAIL="your_cloudflare_account_email"                     # The email you use to login to Cloudflare

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for taking the time to contribute!
 ## Prerequisites
 
 - [Bun](https://bun.sh) ≥ 1.0.0 **or** Node.js ≥ 22.0.0
-- A Cloudflare **Global API Key** and account email to test the tool against a real account
+- A Cloudflare **Create Additional Tokens Key** and account email to test the tool against a real account
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Creating API tokens through the Cloudflare dashboard involves navigating nested 
 - A Cloudflare **Create Additional Tokens Key** (create one at My Profile > API Tokens > Create Token > Create Additional Tokens)
 - Your Cloudflare account email
 
-Optionally, set `CF_EMAIL` to automatically supply your email and skip the interactive email prompt.
-Optionally, set `CF_API_TOKEN` to automatically supply your Create Additional Tokens Key and skip the interactive API key prompt.
+Optionally, set `CF_API_TOKEN` to automatically supply your Create Additional Tokens Key and skip the interactive token prompt.
 
 ## Install
 
@@ -48,7 +47,7 @@ create-cf-token
 
 ## Flow
 
-1. Authenticate with your Cloudflare email and Create Additional Tokens Key
+1. Authenticate with your Create Additional Tokens Key
 2. Select which accounts the token should cover by typing to filter the list
 3. Pick scopes and choose read or read+write access for each, again with live fuzzy filtering
 4. Name the token

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Creating API tokens through the Cloudflare dashboard involves navigating nested 
 ## Prerequisites
 
 - Node.js 22+
-- A Cloudflare **Global API Key** (found under My Profile > API Tokens)
+- A Cloudflare **Create Additional Tokens Key** (create one at My Profile > API Tokens > Create Token > Create Additional Tokens)
 - Your Cloudflare account email
 
 Optionally, set `CF_EMAIL` to automatically supply your email and skip the interactive email prompt.
-Optionally, set `CF_API_TOKEN` to automatically supply your Global API Key and skip the interactive API key prompt.
+Optionally, set `CF_API_TOKEN` to automatically supply your Create Additional Tokens Key and skip the interactive API key prompt.
 
 ## Install
 
@@ -48,7 +48,7 @@ create-cf-token
 
 ## Flow
 
-1. Authenticate with your Cloudflare email and Global API Key
+1. Authenticate with your Cloudflare email and Create Additional Tokens Key
 2. Select which accounts the token should cover by typing to filter the list
 3. Pick scopes and choose read or read+write access for each, again with live fuzzy filtering
 4. Name the token

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ Use GitHub's private vulnerability reporting:
 
 Security issues relevant to this project include:
 
-- **Credential exposure** — Cloudflare Global API Keys, account emails, or created tokens being leaked through logs, error output, process arguments, or environment variable handling.
+- **Credential exposure** — Cloudflare Create Additional Tokens Keys, account emails, or created tokens being leaked through logs, error output, process arguments, or environment variable handling.
 - **Token scope creep** — the tool granting broader permissions than the user selected due to a logic error in scope resolution.
 - **Denial of service** — pathological parsing of untrusted Cloudflare API responses or user-provided input causing the CLI to hang or degrade severely.
 - **Command injection** — user-supplied input being passed unsafely to shell commands or the Cloudflare API.

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -42,7 +42,6 @@ describe("getUser", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -68,7 +67,6 @@ describe("getUser — API error", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -93,7 +91,6 @@ describe("getAccounts", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -119,7 +116,6 @@ describe("getPermissionGroups", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -147,7 +143,6 @@ describe("createToken — success", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -185,7 +180,6 @@ describe("createToken — restricted permission", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -213,7 +207,6 @@ describe("createToken — generic failure", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -238,7 +231,6 @@ describe("createToken — non-JSON response", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -271,7 +263,6 @@ describe("createToken — restricted perm in raw text fallback", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -299,7 +290,6 @@ describe("deleteToken — success", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -324,7 +314,6 @@ describe("deleteToken — failure", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -352,7 +341,6 @@ describe("deleteToken — non-JSON response", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 
@@ -381,7 +369,6 @@ describe("auth headers", () => {
 
   afterAll(() => {
     server.stop();
-    // biome-ignore lint/performance/noDelete: process.env.delete properly removes the property
     delete process.env.CF_API_BASE_URL;
   });
 

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -46,7 +46,7 @@ describe("getUser", () => {
   });
 
   test("returns Ok with user info on success", async () => {
-    const result = await getUser("email@test.com", "key");
+    const result = await getUser("key");
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.id).toBe("user-123");
@@ -71,7 +71,7 @@ describe("getUser — API error", () => {
   });
 
   test("returns Err(CloudflareApiError) when success is false", async () => {
-    const result = await getUser("email@test.com", "key");
+    const result = await getUser("key");
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(CloudflareApiError);
@@ -95,7 +95,7 @@ describe("getAccounts", () => {
   });
 
   test("returns Ok with accounts array on success", async () => {
-    const result = await getAccounts("email@test.com", "key");
+    const result = await getAccounts("key");
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value).toHaveLength(1);
@@ -120,7 +120,7 @@ describe("getPermissionGroups", () => {
   });
 
   test("returns Ok with permission groups on success", async () => {
-    const result = await getPermissionGroups("email@test.com", "key");
+    const result = await getPermissionGroups("key");
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value[0]?.name).toBe("DNS Read");
@@ -147,7 +147,7 @@ describe("createToken — success", () => {
   });
 
   test("returns Ok(CreatedToken) on success", async () => {
-    const result = await createToken("My Token", [], "email@test.com", "key");
+    const result = await createToken("My Token", [], "key");
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value.id).toBe("tok-abc");
@@ -184,7 +184,7 @@ describe("createToken — restricted permission", () => {
   });
 
   test("returns Err(RestrictedPermissionError) when permission group is named in error", async () => {
-    const result = await createToken("My Token", [], "email@test.com", "key");
+    const result = await createToken("My Token", [], "key");
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(RestrictedPermissionError);
@@ -211,7 +211,7 @@ describe("createToken — generic failure", () => {
   });
 
   test("returns Err(TokenCreationError) for non-restricted failures", async () => {
-    const result = await createToken("My Token", [], "email@test.com", "key");
+    const result = await createToken("My Token", [], "key");
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(TokenCreationError);
@@ -235,7 +235,7 @@ describe("createToken — non-JSON response", () => {
   });
 
   test("treats non-JSON error responses as token creation failures", async () => {
-    const result = await createToken("test", [], "user@example.com", "api-key");
+    const result = await createToken("test", [], "api-key");
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(TokenCreationError);
@@ -267,7 +267,7 @@ describe("createToken — restricted perm in raw text fallback", () => {
   });
 
   test("falls back to raw response text when structured messages miss the permission name", async () => {
-    const result = await createToken("test", [], "user@example.com", "api-key");
+    const result = await createToken("test", [], "api-key");
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(RestrictedPermissionError);
@@ -294,7 +294,7 @@ describe("deleteToken — success", () => {
   });
 
   test("returns Ok(id) on successful deletion", async () => {
-    const result = await deleteToken("tok-123", "email@test.com", "key");
+    const result = await deleteToken("tok-123", "key");
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       expect(result.value).toBe("tok-123");
@@ -318,7 +318,7 @@ describe("deleteToken — failure", () => {
   });
 
   test("returns Err(TokenDeletionError) on failure", async () => {
-    const result = await deleteToken("tok-bad", "email@test.com", "key");
+    const result = await deleteToken("tok-bad", "key");
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(TokenDeletionError);
@@ -345,7 +345,7 @@ describe("deleteToken — non-JSON response", () => {
   });
 
   test("treats non-JSON error responses as token deletion failures", async () => {
-    const result = await deleteToken("tok-err", "user@example.com", "api-key");
+    const result = await deleteToken("tok-err", "api-key");
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(TokenDeletionError);
@@ -372,9 +372,8 @@ describe("auth headers", () => {
     delete process.env.CF_API_BASE_URL;
   });
 
-  test("sends X-Auth-Email and X-Auth-Key headers", async () => {
-    await getUser("myemail@test.com", "my-api-key");
-    expect(capturedHeaders["x-auth-email"]).toBe("myemail@test.com");
-    expect(capturedHeaders["x-auth-key"]).toBe("my-api-key");
+  test("sends Authorization Bearer header", async () => {
+    await getUser("my-api-key");
+    expect(capturedHeaders.authorization).toBe("Bearer my-api-key");
   });
 });

--- a/__tests__/cli.e2e.test.ts
+++ b/__tests__/cli.e2e.test.ts
@@ -55,7 +55,6 @@ describe("CLI e2e — auth failure", () => {
       "/user": errorResponse(["Invalid API key"], 401),
     });
     baseEnv = {
-      CF_EMAIL: "test@example.com",
       CF_API_TOKEN: "bad-key",
       CF_API_BASE_URL: server.baseUrl,
     };
@@ -79,7 +78,6 @@ describe("CLI e2e — auth failure", () => {
 describe("CLI e2e — network unreachable", () => {
   test("exits with code 1 when the API base URL is unreachable", async () => {
     const { exitCode } = await spawnCli([], {
-      CF_EMAIL: "test@example.com",
       CF_API_TOKEN: "any-key",
       CF_API_BASE_URL: "http://127.0.0.1:1",
     });
@@ -99,7 +97,6 @@ describe("CLI e2e — cancel via closed stdin", () => {
       "/user/tokens/permission_groups": successResponse(PERMS_FIXTURE),
     });
     baseEnv = {
-      CF_EMAIL: "test@example.com",
       CF_API_TOKEN: "valid-key",
       CF_API_BASE_URL: server.baseUrl,
     };
@@ -125,7 +122,7 @@ describe("CLI e2e — happy API path (auth + fetch)", () => {
     authCalls = [];
     server = startTestServer({
       "/user": (req) => {
-        authCalls.push(req.headers.get("x-auth-email") ?? "");
+        authCalls.push(req.headers.get("authorization") ?? "");
         return successResponse(USER_FIXTURE);
       },
       "/accounts": successResponse(ACCOUNTS_FIXTURE),
@@ -137,17 +134,15 @@ describe("CLI e2e — happy API path (auth + fetch)", () => {
 
   test("sends correct auth headers to the API", async () => {
     await spawnCli([], {
-      CF_EMAIL: "my@email.com",
       CF_API_TOKEN: "my-api-key",
       CF_API_BASE_URL: server.baseUrl,
     });
-    expect(authCalls[0]).toBe("my@email.com");
+    expect(authCalls[0]).toBe("Bearer my-api-key");
   });
 
   test("reaches account fetch stage before cancelling interactive prompts", async () => {
     // If the process reaches the interactive select stage it means auth + accounts + perms all succeeded
     const { stdout } = await spawnCli([], {
-      CF_EMAIL: "test@example.com",
       CF_API_TOKEN: "valid-key",
       CF_API_BASE_URL: server.baseUrl,
     });

--- a/__tests__/cli.node.e2e.test.ts
+++ b/__tests__/cli.node.e2e.test.ts
@@ -119,7 +119,6 @@ describe("dist/cli.mjs — auth failure", () => {
 
   test.skipIf(!distExists)("exits 1 on authentication failure", async () => {
     const { exitCode } = await spawnNode([], {
-      CF_EMAIL: "test@example.com",
       CF_API_TOKEN: "bad-key",
       CF_API_BASE_URL: server.baseUrl,
     });
@@ -155,7 +154,6 @@ describe("dist/cli.mjs — successful API fetch", () => {
     "reaches prompt stage after successful API calls",
     async () => {
       const { stdout } = await spawnNode([], {
-        CF_EMAIL: "test@example.com",
         CF_API_TOKEN: "valid-key",
         CF_API_BASE_URL: server.baseUrl,
       });

--- a/assets/social-preview.html
+++ b/assets/social-preview.html
@@ -420,7 +420,7 @@
                 <span class="b">john@acme.com</span>
               </div>
               <div>
-                <span class="c">&gt; </span><span class="r">Global API Key</span>
+                <span class="c">&gt; </span><span class="r">Create Additional Tokens Key</span>
                 <span class="hidden-text">••••••••••••</span>
               </div>
               <br>

--- a/assets/social-preview.html
+++ b/assets/social-preview.html
@@ -416,10 +416,6 @@
               </div>
               <br>
               <div>
-                <span class="c">&gt; </span><span class="r">Cloudflare email</span>
-                <span class="b">john@acme.com</span>
-              </div>
-              <div>
                 <span class="c">&gt; </span><span class="r">Create Additional Tokens Key</span>
                 <span class="hidden-text">••••••••••••</span>
               </div>

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
         "@types/bun": "^1.3.12",
-        "@types/node": "~25.6.0",
+        "@types/node": "~22.19.15",
         "@typescript/native-preview": "^7.0.0-dev.20260413.1",
         "lefthook": "^2.1.5",
         "tsdown": "^0.21.8",
@@ -173,7 +173,7 @@
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260413.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260413.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260413.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-twzr3V4QLEbXaESuI2DqdzutOVFGpkY3VZDR9sF8YlLsAXkwyQvZo58cKM77mZcsHoCR4lCYcdTatWTTa/+8tw=="],
 
@@ -447,7 +447,7 @@
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
@@ -469,6 +469,8 @@
 
     "@quansync/fs/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
+    "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "nypm/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
@@ -478,6 +480,8 @@
     "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "unrun/rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,15 +10,15 @@
         "better-result": "^2.8.2",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.10",
+        "@biomejs/biome": "2.4.11",
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
-        "@types/bun": "^1.3.11",
-        "@types/node": "~22.19.15",
-        "@typescript/native-preview": "^7.0.0-dev.20260408.1",
+        "@types/bun": "^1.3.12",
+        "@types/node": "~25.6.0",
+        "@typescript/native-preview": "^7.0.0-dev.20260413.1",
         "lefthook": "^2.1.5",
-        "tsdown": "^0.21.7",
-        "ultracite": "7.4.3",
+        "tsdown": "^0.21.8",
+        "ultracite": "7.5.6",
       },
       "peerDependencies": {
         "typescript": "^6.0.2",
@@ -41,23 +41,23 @@
 
     "@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.10", "", { "os": "linux", "cpu": "x64" }, "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.0", "", { "dependencies": { "@changesets/config": "^3.1.3", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ=="],
 
@@ -101,11 +101,11 @@
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
 
-    "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
+    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -121,7 +121,7 @@
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -129,67 +129,67 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
+    "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm" }, "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "x64" }, "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.12", "", { "os": "linux", "cpu": "x64" }, "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.12", "", { "os": "none", "cpu": "arm64" }, "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.12", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "x64" }, "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.12", "", {}, "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
-    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260408.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260408.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260408.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260408.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260408.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260408.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260408.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260408.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-N0MZLEUnAoP/aRVk7MY119LDsESkbtEwIw+YeXi/jjx2XCqf7ni3GxIVsUYtf/troyuSedq3V/OUrkoCh5A9gA=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260413.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260413.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260413.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260413.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-twzr3V4QLEbXaESuI2DqdzutOVFGpkY3VZDR9sF8YlLsAXkwyQvZo58cKM77mZcsHoCR4lCYcdTatWTTa/+8tw=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260408.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YcPczNLfPDB13eUBYHkTOkL7HyWqqqEhho4eSxhAvigZuxvtHQ1uyILIvLVAwipEVzhJ8QciKmLdLucpfi4XyA=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260413.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CDgxIPvAWRCfOiQKvSk4wUkAoRW4Cy6vfAUBPNHSeLalIt43ToF0LOAsa5uLyRGsftjfMYY0A4qFOmgDvBhgzQ=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260408.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-cHqkDg53xxxz21MThLBf4vx1kyIpRPEYNdEiQlvu9O35Tth49+aub6F+/YEMd9MG4TYZmxh1bEjkjErTUIElpA=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260413.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-oiMmUtNMaqBh+eUogX53ichcEf7d+7upC0qa7xS9zWl85XEPKlrZCZpZ79yixw1PkdpjqJJigI11bmCi/JVv+g=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260408.1", "", { "os": "linux", "cpu": "arm" }, "sha512-w26Gv9yq9LIYIhxjkQC+i0wBPDdQdX+H06ZhyVRL5grKWTIsk9Xwjp9mDRB/dGlXBKcvnM25JH16OyAA0rFH3A=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260413.1", "", { "os": "linux", "cpu": "arm" }, "sha512-0lSXBzBVsxIGrFv/PxoswzMptsnU6BgSk7GMAUt/o1dVw36R2XrSs538vwKnujaJwt4iIdMS0uGdpUC5s9jkzQ=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260408.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-iHG0FEXq/QFsn+qlTPllxdcbvfQ9aRYggy4lc1z0+f11Nyk4YDNCSiR8WW7pbnOTx/VreGbbXhlpuJXTidqL8g=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260413.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-hPKanfs9c+7953gIYw13CNxN0HqFAOfJjnWk4SHqSBe3Pj9pxoeJvvRWlofp5C833eOZK6gZB7ll0/uNb0djtA=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260408.1", "", { "os": "linux", "cpu": "x64" }, "sha512-hMcUlUIzYbvbdq6j/B4RPL+kZR917NGnE9AgPZ7dJ92yamH/7LGT1Mnlc6McUx31yqTFBFHdTc7Cfx+ynua7Iw=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260413.1", "", { "os": "linux", "cpu": "x64" }, "sha512-8Cr477HRmHZ5YyLfikNvw7qp3/WmnRjzIzJhUDrAx5173OBe8BdyV9jPemFHKDPqwI1AUMTijvptOFoQE7429w=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260408.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-avJWIEKSx4rdBLZD1FOOTuxTU51dQfYb3jZvZMaXD4thJjq+6eSwfzu2elwL36AZDlnaxggGjB5nBxp0t54iOA=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260413.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-ulJD9ZbIQyTBIDx8zzAzQLtbvQDGHSWrNRgkgBU5Os2NTYADQRco4pU747R9wZPMLopy3IeNck6m8vwPoYMk1g=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260408.1", "", { "os": "win32", "cpu": "x64" }, "sha512-gpvEHkF/WoxkA3711c4uWNCZO9WAuwrq49COdNwxgOTzYHnMc1yCj8CpkCUJwU0f/Ydwp2s6/efn6gTMvtckPg=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260413.1", "", { "os": "win32", "cpu": "x64" }, "sha512-x7DsSXnLQBf5XBBR8luHf1Nc/T1eByUmrOSEThW6825UB7lHoPlqKdhIoUNnTnS4nXQMxLwcusD4P1EP23GPJw=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -215,7 +215,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
@@ -397,7 +397,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
+    "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.23.2", "", { "dependencies": { "@babel/generator": "8.0.0-rc.3", "@babel/helper-validator-identifier": "8.0.0-rc.3", "@babel/parser": "8.0.0-rc.3", "@babel/types": "8.0.0-rc.3", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.7", "obug": "^2.1.1", "picomatch": "^4.0.4" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0-rc.12", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ=="],
 
@@ -427,9 +427,9 @@
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
-    "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
+    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -437,17 +437,17 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
-    "tsdown": ["tsdown@0.21.7", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^7.0.0", "defu": "^6.1.4", "empathic": "^2.0.0", "hookable": "^6.1.0", "import-without-cache": "^0.2.5", "obug": "^2.1.1", "picomatch": "^4.0.4", "rolldown": "1.0.0-rc.12", "rolldown-plugin-dts": "^0.23.2", "semver": "^7.7.4", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "unrun": "^0.2.34" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.7", "@tsdown/exe": "0.21.7", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "typescript", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-ukKIxKQzngkWvOYJAyptudclkm4VQqbjq+9HF5K5qDO8GJsYtMh8gIRwicbnZEnvFPr6mquFwYAVZ8JKt3rY2g=="],
+    "tsdown": ["tsdown@0.21.8", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.0", "hookable": "^6.1.0", "import-without-cache": "^0.2.5", "obug": "^2.1.1", "picomatch": "^4.0.4", "rolldown": "1.0.0-rc.15", "rolldown-plugin-dts": "^0.23.2", "semver": "^7.7.4", "tinyexec": "^1.1.1", "tinyglobby": "^0.2.16", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "unrun": "^0.2.34" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.8", "@tsdown/exe": "0.21.8", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "typescript", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-rHDIER4JU5owYTWptvyDk6pwfA5lCft1P+11HLGeF0uj0CB7vopFvr/E8QOaRmegeyHIEsu4+03j7ysvdgBAVA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
-    "ultracite": ["ultracite@7.4.3", "", { "dependencies": { "@clack/prompts": "^1.1.0", "commander": "^14.0.3", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.5" }, "peerDependencies": { "oxlint": "^1.0.0" }, "optionalPeers": ["oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-HMnd21OpSSwi/YtNqXUP/798dlTQ2GlXh0wR+8rIVY9uCTTQiOiRthdLlRaAo6IqUT0l29hiRl+ShsO0r81LtQ=="],
+    "ultracite": ["ultracite@7.5.6", "", { "dependencies": { "@clack/prompts": "^1.2.0", "commander": "^14.0.3", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.5" }, "peerDependencies": { "oxlint": "^1.0.0" }, "optionalPeers": ["oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-lWHFAq7NP2tUxANFMcJW5JW14NsQ7EKlYz4+NTSUGD16a52j6yBkIenv0A+qpFBzpCXmZ0SdD0Bjh3yNkY8dGA=="],
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
@@ -469,16 +469,52 @@
 
     "@quansync/fs/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
-    "bun-types/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
-
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "nypm/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
-    "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "unrun/rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "unrun/rolldown/@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
+
+    "unrun/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
+
+    "unrun/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg=="],
+
+    "unrun/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw=="],
+
+    "unrun/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm" }, "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "x64" }, "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg=="],
+
+    "unrun/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.12", "", { "os": "linux", "cpu": "x64" }, "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig=="],
+
+    "unrun/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.12", "", { "os": "none", "cpu": "arm64" }, "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA=="],
+
+    "unrun/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.12", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg=="],
+
+    "unrun/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q=="],
+
+    "unrun/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "x64" }, "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw=="],
+
+    "unrun/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.12", "", {}, "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw=="],
+
+    "unrun/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
     "@types/bun": "^1.3.12",
-    "@types/node": "~25.6.0",
+    "@types/node": "~22.19.15",
     "@typescript/native-preview": "^7.0.0-dev.20260413.1",
     "lefthook": "^2.1.5",
     "tsdown": "^0.21.8",

--- a/package.json
+++ b/package.json
@@ -79,15 +79,15 @@
     "test:node": "bun run build && bun test __tests__/cli.node.e2e.test.ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.10",
+    "@biomejs/biome": "2.4.11",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
-    "@types/bun": "^1.3.11",
-    "@types/node": "~22.19.15",
-    "@typescript/native-preview": "^7.0.0-dev.20260408.1",
+    "@types/bun": "^1.3.12",
+    "@types/node": "~25.6.0",
+    "@typescript/native-preview": "^7.0.0-dev.20260413.1",
     "lefthook": "^2.1.5",
-    "tsdown": "^0.21.7",
-    "ultracite": "7.4.3"
+    "tsdown": "^0.21.8",
+    "ultracite": "7.5.6"
   },
   "peerDependencies": {
     "typescript": "^6.0.2"

--- a/src/api.ts
+++ b/src/api.ts
@@ -65,7 +65,7 @@ function tryParseJson<T>(text: string): T | null {
  * Build the authentication headers required by the Cloudflare API.
  *
  * @param email - The user's Cloudflare account email.
- * @param apiKey - The user's Global API Key.
+ * @param apiKey - The user's Create Additional Tokens Key.
  * @returns Headers object with `X-Auth-Email` and `X-Auth-Key`.
  */
 function authHeaders(email: string, apiKey: string) {
@@ -79,7 +79,7 @@ function authHeaders(email: string, apiKey: string) {
  * @typeParam T - Expected shape of the `result` field.
  * @param path - API path (e.g. `"/user"` or `"/accounts?per_page=50"`).
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @returns A `Result<T, CloudflareApiError | UnhandledException>`.
  */
 function cfGet<T>(
@@ -116,7 +116,7 @@ function cfGet<T>(
  * Fetch the authenticated user's profile.
  *
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @returns `Result<UserInfo, CloudflareApiError | UnhandledException>`
  */
 export function getUser(
@@ -130,7 +130,7 @@ export function getUser(
  * Fetch all accounts the authenticated user has access to (up to 50).
  *
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @returns `Result<Account[], CloudflareApiError | UnhandledException>`
  */
 export function getAccounts(
@@ -144,7 +144,7 @@ export function getAccounts(
  * Fetch all available permission groups for API tokens.
  *
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @returns `Result<PermissionGroup[], CloudflareApiError | UnhandledException>`
  */
 export function getPermissionGroups(
@@ -168,7 +168,7 @@ export function getPermissionGroups(
  * @param name - Human-readable token name.
  * @param policies - Array of {@linkcode Policy} objects defining permissions.
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @returns `Result<CreatedToken, RestrictedPermissionError | TokenCreationError | UnhandledException>`
  */
 export function createToken(
@@ -236,7 +236,7 @@ export function createToken(
  *
  * @param tokenId - The unique identifier of the token to delete.
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @returns `Result<string, TokenDeletionError | UnhandledException>` — the deleted token's ID on success.
  */
 export function deleteToken(

--- a/src/api.ts
+++ b/src/api.ts
@@ -64,12 +64,11 @@ function tryParseJson<T>(text: string): T | null {
 /**
  * Build the authentication headers required by the Cloudflare API.
  *
- * @param email - The user's Cloudflare account email.
- * @param apiKey - The user's Create Additional Tokens Key.
- * @returns Headers object with `X-Auth-Email` and `X-Auth-Key`.
+ * @param token - The user's Create Additional Tokens Key (Bearer token).
+ * @returns Headers object with `Authorization`.
  */
-function authHeaders(email: string, apiKey: string) {
-  return { "X-Auth-Email": email, "X-Auth-Key": apiKey };
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}` };
 }
 
 /**
@@ -79,18 +78,17 @@ function authHeaders(email: string, apiKey: string) {
  * @typeParam T - Expected shape of the `result` field.
  * @param path - API path (e.g. `"/user"` or `"/accounts?per_page=50"`).
  * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @returns A `Result<T, CloudflareApiError | UnhandledException>`.
  */
 function cfGet<T>(
   path: string,
-  email: string,
-  apiKey: string
+  token: string
 ): Promise<Result<T, CloudflareApiError | UnhandledException>> {
   return Result.tryPromise({
     try: async () => {
       const res = await fetch(`${cfApiBase()}${path}`, {
-        headers: authHeaders(email, apiKey),
+        headers: authHeaders(token),
       });
       const json = (await res.json()) as {
         success: boolean;
@@ -115,47 +113,37 @@ function cfGet<T>(
 /**
  * Fetch the authenticated user's profile.
  *
- * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @returns `Result<UserInfo, CloudflareApiError | UnhandledException>`
  */
 export function getUser(
-  email: string,
-  apiKey: string
+  token: string
 ): Promise<Result<UserInfo, CloudflareApiError | UnhandledException>> {
-  return cfGet<UserInfo>("/user", email, apiKey);
+  return cfGet<UserInfo>("/user", token);
 }
 
 /**
  * Fetch all accounts the authenticated user has access to (up to 50).
  *
- * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @returns `Result<Account[], CloudflareApiError | UnhandledException>`
  */
 export function getAccounts(
-  email: string,
-  apiKey: string
+  token: string
 ): Promise<Result<Account[], CloudflareApiError | UnhandledException>> {
-  return cfGet<Account[]>("/accounts?per_page=50", email, apiKey);
+  return cfGet<Account[]>("/accounts?per_page=50", token);
 }
 
 /**
  * Fetch all available permission groups for API tokens.
  *
- * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @returns `Result<PermissionGroup[], CloudflareApiError | UnhandledException>`
  */
 export function getPermissionGroups(
-  email: string,
-  apiKey: string
+  token: string
 ): Promise<Result<PermissionGroup[], CloudflareApiError | UnhandledException>> {
-  return cfGet<PermissionGroup[]>(
-    "/user/tokens/permission_groups",
-    email,
-    apiKey
-  );
+  return cfGet<PermissionGroup[]>("/user/tokens/permission_groups", token);
 }
 
 /**
@@ -167,15 +155,13 @@ export function getPermissionGroups(
  *
  * @param name - Human-readable token name.
  * @param policies - Array of {@linkcode Policy} objects defining permissions.
- * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @returns `Result<CreatedToken, RestrictedPermissionError | TokenCreationError | UnhandledException>`
  */
 export function createToken(
   name: string,
   policies: Policy[],
-  email: string,
-  apiKey: string
+  token: string
 ): Promise<
   Result<
     CreatedToken,
@@ -187,7 +173,7 @@ export function createToken(
       const res = await fetch(`${cfApiBase()}/user/tokens`, {
         method: "POST",
         headers: {
-          ...authHeaders(email, apiKey),
+          ...authHeaders(token),
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ name, policies }),
@@ -235,20 +221,18 @@ export function createToken(
  * Delete (revoke) a Cloudflare API token by its ID.
  *
  * @param tokenId - The unique identifier of the token to delete.
- * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @returns `Result<string, TokenDeletionError | UnhandledException>` — the deleted token's ID on success.
  */
 export function deleteToken(
   tokenId: string,
-  email: string,
-  apiKey: string
+  token: string
 ): Promise<Result<string, TokenDeletionError | UnhandledException>> {
   return Result.tryPromise({
     try: async () => {
       const res = await fetch(`${cfApiBase()}/user/tokens/${tokenId}`, {
         method: "DELETE",
-        headers: authHeaders(email, apiKey),
+        headers: authHeaders(token),
       });
       const text = await res.text();
       const json = tryParseJson<DeleteTokenResponse>(text);

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,6 @@ const HELP_TEXT = `
 
   ${WHITE}Environment Variables${RESET}
 
-    ${CYAN}CF_EMAIL${RESET}              Automatically supplies the Cloudflare account email and skips the prompt
     ${CYAN}CF_API_TOKEN${RESET}          Cloudflare Create Additional Tokens Key for authentication
 
   ${DIM}https://github.com/mynameistito/create-cf-token${RESET}
@@ -184,8 +183,7 @@ export function buildPolicies(
  * @param zonePerms - Zone-scoped permission groups.
  * @param userResources - Resource URI map for user permissions.
  * @param accountResources - Resource URI map for account/zone permissions.
- * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @param s - Clack spinner instance for progress feedback.
  * @returns The created token on success.
  * @throws {TokenCreationFlowError} On unrecoverable errors or max retries exceeded.
@@ -197,8 +195,7 @@ async function attemptCreateToken(
   zonePerms: PermissionGroup[],
   userResources: Record<string, string>,
   accountResources: Record<string, string>,
-  email: string,
-  apiKey: string,
+  token: string,
   s: ReturnType<typeof createSpinner>
 ): Promise<CreatedToken> {
   const excluded = new Set<string>(["API Tokens"]);
@@ -223,7 +220,7 @@ async function attemptCreateToken(
       });
     }
 
-    const result = await createToken(tokenName, policies, email, apiKey);
+    const result = await createToken(tokenName, policies, token);
 
     if (result.isOk()) {
       s.stop(`Token created (attempt ${attempt})`);
@@ -285,8 +282,7 @@ async function attemptCreateToken(
  * @param accounts - Accounts available for selection.
  * @param scopes - Permission groups organised by service.
  * @param userId - The authenticated user's ID (used in resource URIs).
- * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @param s - Clack spinner instance.
  * @returns The created token.
  * @throws {TokenCreationFlowError} If the flow exits unexpectedly.
@@ -295,8 +291,7 @@ async function createTokenFlow(
   accounts: Account[],
   scopes: ReturnType<typeof groupByService>,
   userId: string,
-  email: string,
-  apiKey: string,
+  token: string,
   s: ReturnType<typeof createSpinner>
 ): Promise<CreatedToken> {
   let selectedAccounts = await selectAccounts(accounts);
@@ -347,8 +342,7 @@ async function createTokenFlow(
       zonePerms,
       userResources,
       accountResources,
-      email,
-      apiKey,
+      token,
       s
     );
     choosingToken = false;
@@ -364,15 +358,13 @@ async function createTokenFlow(
  * Delete one or more API tokens by their IDs.
  *
  * @param tokensToDelete - Tokens to revoke.
- * @param email - Cloudflare account email.
- * @param apiKey - Create Additional Tokens Key.
+ * @param token - Create Additional Tokens Key.
  * @param s - Clack spinner instance for progress feedback.
  * @throws {TokenDeletionFlowError} If any deletion fails.
  */
 async function deleteTokens(
   tokensToDelete: CreatedToken[],
-  email: string,
-  apiKey: string,
+  authToken: string,
   s: ReturnType<typeof createSpinner>
 ): Promise<void> {
   s.start(
@@ -380,7 +372,7 @@ async function deleteTokens(
   );
 
   for (const token of tokensToDelete) {
-    const result = await deleteToken(token.id, email, apiKey);
+    const result = await deleteToken(token.id, authToken);
 
     if (result.isErr()) {
       s.stop("Failed");
@@ -415,7 +407,7 @@ export function handleApiError(error: ApiError): never {
   matchError(error, {
     CloudflareApiError: (e) => {
       cancelPrompt(
-        `${e.message}\n\nYour API key or email may be incorrect.\nGet your Create Additional Tokens Key: ${colour.CYAN}${CF_API_TOKENS_URL}${colour.RESET}`
+        `${e.message}\n\nYour token may be incorrect.\nGet your Create Additional Tokens Key: ${colour.CYAN}${CF_API_TOKENS_URL}${colour.RESET}`
       );
     },
     UnhandledException: (e) => cancelPrompt(e.message),
@@ -461,19 +453,19 @@ export async function main(): Promise<void> {
     [
       `${colour.DIM}A CLI tool for creating ${colour.WHITE}Cloudflare API Tokens${colour.RESET}${colour.DIM} with interactive, guided prompts.`,
       "",
-      `${colour.DIM}You'll need your ${colour.WHITE}Account Email${colour.RESET}${colour.DIM} and ${colour.WHITE}Create Additional Tokens Key${colour.RESET}${colour.DIM}.`,
+      `${colour.DIM}You'll need a ${colour.WHITE}Create Additional Tokens Key${colour.RESET}${colour.DIM}.`,
       `${colour.DIM}Get your key: ${colour.CYAN}${CF_API_TOKENS_URL}${colour.RESET}${colour.DIM} → Create Token → ${colour.WHITE}Create Additional Tokens${colour.RESET}${colour.DIM} template`,
     ].join("\n"),
     "create-cf-token"
   );
 
-  const { email, apiKey } = await askCredentials();
+  const { token } = await askCredentials();
 
   const s = createSpinner();
 
   // Fetch user
   s.start("Fetching user info...");
-  const userResult = await getUser(email, apiKey);
+  const userResult = await getUser(token);
   if (userResult.isErr()) {
     s.stop("Failed");
     handleApiError(userResult.error);
@@ -483,7 +475,7 @@ export async function main(): Promise<void> {
 
   // Fetch accounts
   s.start("Fetching accounts...");
-  const accountsResult = await getAccounts(email, apiKey);
+  const accountsResult = await getAccounts(token);
   if (accountsResult.isErr()) {
     s.stop("Failed");
     handleApiError(accountsResult.error);
@@ -493,7 +485,7 @@ export async function main(): Promise<void> {
 
   // Fetch permissions & group by service (once, reused across all tokens)
   s.start("Fetching permission groups...");
-  const permsResult = await getPermissionGroups(email, apiKey);
+  const permsResult = await getPermissionGroups(token);
   if (permsResult.isErr()) {
     s.stop("Failed");
     handleApiError(permsResult.error);
@@ -512,20 +504,19 @@ export async function main(): Promise<void> {
         accounts,
         scopes,
         user.id,
-        email,
-        apiKey,
+        token,
         s
       );
 
       if (previousToken) {
-        await deleteTokens([previousToken], email, apiKey, s);
+        await deleteTokens([previousToken], token, s);
         previousToken = undefined;
       }
 
       const action = await askPostCreateAction();
 
       if (action === "revoke-done") {
-        await deleteTokens([createdToken], email, apiKey, s);
+        await deleteTokens([createdToken], token, s);
       } else if (action === "revoke-again") {
         previousToken = createdToken;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ const HELP_TEXT = `
   ${WHITE}Environment Variables${RESET}
 
     ${CYAN}CF_EMAIL${RESET}              Automatically supplies the Cloudflare account email and skips the prompt
-    ${CYAN}CF_API_TOKEN${RESET}          Cloudflare Global API Key for authentication
+    ${CYAN}CF_API_TOKEN${RESET}          Cloudflare Create Additional Tokens Key for authentication
 
   ${DIM}https://github.com/mynameistito/create-cf-token${RESET}
 `;
@@ -185,7 +185,7 @@ export function buildPolicies(
  * @param userResources - Resource URI map for user permissions.
  * @param accountResources - Resource URI map for account/zone permissions.
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @param s - Clack spinner instance for progress feedback.
  * @returns The created token on success.
  * @throws {TokenCreationFlowError} On unrecoverable errors or max retries exceeded.
@@ -286,7 +286,7 @@ async function attemptCreateToken(
  * @param scopes - Permission groups organised by service.
  * @param userId - The authenticated user's ID (used in resource URIs).
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @param s - Clack spinner instance.
  * @returns The created token.
  * @throws {TokenCreationFlowError} If the flow exits unexpectedly.
@@ -365,7 +365,7 @@ async function createTokenFlow(
  *
  * @param tokensToDelete - Tokens to revoke.
  * @param email - Cloudflare account email.
- * @param apiKey - Global API Key.
+ * @param apiKey - Create Additional Tokens Key.
  * @param s - Clack spinner instance for progress feedback.
  * @throws {TokenDeletionFlowError} If any deletion fails.
  */
@@ -415,7 +415,7 @@ export function handleApiError(error: ApiError): never {
   matchError(error, {
     CloudflareApiError: (e) => {
       cancelPrompt(
-        `${e.message}\n\nYour API key or email may be incorrect.\nGet your Global API Key: ${colour.CYAN}${CF_API_TOKENS_URL}${colour.RESET}`
+        `${e.message}\n\nYour API key or email may be incorrect.\nGet your Create Additional Tokens Key: ${colour.CYAN}${CF_API_TOKENS_URL}${colour.RESET}`
       );
     },
     UnhandledException: (e) => cancelPrompt(e.message),
@@ -461,8 +461,8 @@ export async function main(): Promise<void> {
     [
       `${colour.DIM}A CLI tool for creating ${colour.WHITE}Cloudflare API Tokens${colour.RESET}${colour.DIM} with interactive, guided prompts.`,
       "",
-      `${colour.DIM}You'll need your ${colour.WHITE}Account Email${colour.RESET}${colour.DIM} and ${colour.WHITE}Global API Key${colour.RESET}${colour.DIM}.`,
-      `${colour.DIM}Get your key: ${colour.CYAN}${CF_API_TOKENS_URL}${colour.RESET}`,
+      `${colour.DIM}You'll need your ${colour.WHITE}Account Email${colour.RESET}${colour.DIM} and ${colour.WHITE}Create Additional Tokens Key${colour.RESET}${colour.DIM}.`,
+      `${colour.DIM}Get your key: ${colour.CYAN}${CF_API_TOKENS_URL}${colour.RESET}${colour.DIM} → Create Token → ${colour.WHITE}Create Additional Tokens${colour.RESET}${colour.DIM} template`,
     ].join("\n"),
     "create-cf-token"
   );

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -41,7 +41,6 @@ import {
   select,
   spinner,
   symbol,
-  text,
 } from "@clack/prompts";
 import colour from "#src/colour.ts";
 import type { Account, PermissionGroup, ServiceGroup } from "#src/types.ts";
@@ -854,36 +853,26 @@ function check<T>(value: T | symbol): T {
 }
 
 /**
- * Prompt the user for their Cloudflare email and Create Additional Tokens Key.
+ * Prompt the user for their Cloudflare Create Additional Tokens Key.
  *
- * Checks environment variables first (`CF_EMAIL`, `CF_API_TOKEN`); if unset,
- * shows interactive text/password prompts. Exits the process on cancellation.
+ * Checks the `CF_API_TOKEN` environment variable first; if unset,
+ * shows an interactive password prompt. Exits the process on cancellation.
  *
- * @returns The collected credentials.
+ * @returns The collected token.
  */
 export async function askCredentials(): Promise<{
-  email: string;
-  apiKey: string;
+  token: string;
 }> {
-  const email =
-    process.env.CF_EMAIL ||
-    check(
-      await text({
-        message: `${colour.WHITE}Your Cloudflare account Email:${colour.RESET}`,
-        validate: (v) => (v ? undefined : "Email is required"),
-      })
-    );
-
-  const apiKey =
+  const token =
     process.env.CF_API_TOKEN ||
     check(
       await password({
         message: `${colour.WHITE}Your Cloudflare Create Additional Tokens Key:${colour.RESET}`,
-        validate: (v) => (v ? undefined : "API key is required"),
+        validate: (v) => (v ? undefined : "Token is required"),
       })
     );
 
-  return { email, apiKey };
+  return { token };
 }
 
 /**

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -854,7 +854,7 @@ function check<T>(value: T | symbol): T {
 }
 
 /**
- * Prompt the user for their Cloudflare email and Global API Key.
+ * Prompt the user for their Cloudflare email and Create Additional Tokens Key.
  *
  * Checks environment variables first (`CF_EMAIL`, `CF_API_TOKEN`); if unset,
  * shows interactive text/password prompts. Exits the process on cancellation.
@@ -878,7 +878,7 @@ export async function askCredentials(): Promise<{
     process.env.CF_API_TOKEN ||
     check(
       await password({
-        message: `${colour.WHITE}Your Cloudflare Global API Key:${colour.RESET}`,
+        message: `${colour.WHITE}Your Cloudflare Create Additional Tokens Key:${colour.RESET}`,
         validate: (v) => (v ? undefined : "API key is required"),
       })
     );


### PR DESCRIPTION
## What

Replaces all references to "Global API Key" with "Create Additional Tokens Key" across the codebase. The CLI now tells users to create a scoped key via the Cloudflare dashboard instead of using their all-powerful Global API Key.

## Why

The Global API Key has unrestricted access to an entire Cloudflare account. The "Create Additional Tokens" template key only grants permission to create and manage API tokens, which is all this tool actually needs. Pushing users toward the least-privilege option is the right default.

## Changes

- Updated the welcome note to include instructions: go to the API Tokens page, click Create Token, select the "Create Additional Tokens" template
- Updated the interactive prompt label from "Global API Key" to "Create Additional Tokens Key"
- Updated help text, error messages, and JSDoc across src/api.ts, src/index.ts, src/prompts.ts
- Updated docs: README, CONTRIBUTING, SECURITY, .env.example
- Updated the social preview asset
- Removed 13 inert biome-ignore comments in api.test.ts

## Checklist

- [x] bun run typecheck passes
- [x] bun run check passes
- [x] PR description explains what and why

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces all “Global API Key” references with “Create Additional Tokens Key” and switches authentication to Bearer token. Removes the email prompt, updates docs/assets/tests, and keeps least-privilege as the default.

- **Migration**
  - Set `CF_API_TOKEN` to your Create Additional Tokens Key (API Token).
  - `CF_EMAIL` is no longer required; auth uses `Authorization: Bearer <token>`.
  - Create it at https://dash.cloudflare.com/profile/api-tokens > Create Token > Create Additional Tokens.

<sup>Written for commit e025f9c703d22a6de6b3bb1c0f357afb7ac59668. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

