### PR TITLE
fix: publish releases from staging with oidc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish Package
+      - name: Stage Package Publish
         if: github.ref == 'refs/heads/staging'
-        run: bun changeset publish
+        run: |
+          package_tarball=$(npm pack --silent)
+          npm stage publish "$package_tarball" --provenance --access public
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - staging
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -37,6 +38,7 @@ jobs:
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Upgrade npm
         run: npm install -g npm@latest
@@ -47,14 +49,20 @@ jobs:
       - name: Build Package
         run: bun run build
 
-      - name: Create Release Pull Request or Publish
+      - name: Create Release Pull Request
         id: changesets
+        if: github.ref == 'refs/heads/main'
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bun changeset version
-          publish: bun changeset publish
           commit: "chore: version packages"
           title: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Package
+        if: github.ref == 'refs/heads/staging'
+        run: bun changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary
- split release PR creation from npm publishing
- keep Changesets release PR creation on main
- publish packages only from staging with npm OIDC provenance

## Validation
- bun run typecheck
- bun x ultracite check

## Notes
- repository rules now exclude refs/heads/changeset-release/* so the generated Changesets branch is not blocked by unsigned bot commits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the release flow: create Changesets release PRs on `main`, and publish to `npm` only from `staging` using OIDC provenance with `npm stage publish`.

- **Refactors**
  - Trigger workflow on `staging` in addition to `main`.
  - Create release PR via `changesets/action` only on `main`.
  - On `staging`, build a tarball with `npm pack` and run `npm stage publish --provenance --access public` (replaces `bun changeset publish`).
  - Disable Node `package-manager-cache` during setup to avoid cache issues.

- **Migration**
  - Ensure `staging` has `npm` OIDC permissions for publishing.
  - Update repo rules to exclude `refs/heads/changeset-release/*` to allow bot commits.

<sup>Written for commit 9363b5de342ff2d7168121648daad8765fe4b1a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish releases from staging branch using OIDC provenance
> - Adds `staging` as a trigger branch in [release.yml](.github/workflows/release.yml); the Changesets versioning step is now restricted to `main` and no longer runs `bun changeset publish`.
> - Adds a new staging-only step that packs the package via `npm pack` and publishes it with `npm stage publish --provenance --access public`.
> - Disables `package-manager-cache` in the `setup-node` step.
> - Behavioral Change: publishing is no longer handled by the Changesets action on `main`; it is now a separate step triggered only on `staging`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9363b5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->