### PR TITLE
chore: update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,65 +1,42 @@
 name: CI
 
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
 
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  ci:
-    name: CI
+  check:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        task:
+          - audit
+          - build
+          - check
+          - knip
+          - test
+          - test:node
+          - security:scan
+    name: ${{ matrix.task }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.11"
+          bun-version: 1.3.14
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-
-      - name: Install Dependencies
-        run: |
-          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
-            bun install
-          else
-            bun install --frozen-lockfile
-          fi
-
-      - name: Security Scan
-        run: bun run security:scan
-
-      - name: TypeCheck
-        run: bun run typecheck
-
-      - name: Lint
-        run: bun run check
-
-      - name: Build
-        run: bun run build
-
-      - name: Bun Audit
-        run: bun audit
-
-      - name: npm Audit
-        run: npm install --package-lock-only && npm audit
+      - name: Run task
+        run: bun run ${{ matrix.task }}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "typecheck": "tsgo --noEmit",
     "version-packages": "changeset version",
     "watch": "bun --watch src/cli.ts"
-  }
+  },
   "dependencies": {
     "@clack/core": "^1.4.2",
     "@clack/prompts": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -58,24 +58,26 @@
     }
   },
   "scripts": {
-    "dev": "bun src/cli.ts",
-    "start": "bun src/cli.ts",
-    "watch": "bun --watch src/cli.ts",
+    "audit": "bun audit",
     "build": "tsdown",
     "bump": "bun update --latest && bun add -d @types/node@~22.19.15",
-    "typecheck": "tsgo --noEmit",
+    "changeset": "changeset",
     "check": "ultracite check",
+    "dev": "bun src/cli.ts",
     "fix": "ultracite fix",
+    "knip": "bunx knip@latest",
     "prepare": "lefthook install || true",
     "prepublishOnly": "bun run build",
-    "security:scan": "bun test __tests__/security.test.ts",
-    "changeset": "changeset",
-    "version-packages": "changeset version",
     "release": "bun run build && changeset publish --provenance",
+    "security:scan": "bun test __tests__/security.test.ts",
+    "start": "bun src/cli.ts",
     "test": "bun test",
     "test:coverage": "bun test --coverage",
-    "test:node": "bun run build && bun test __tests__/cli.node.e2e.test.ts"
-  },
+    "test:node": "bun run build && bun test __tests__/cli.node.e2e.test.ts",
+    "typecheck": "tsgo --noEmit",
+    "version-packages": "changeset version",
+    "watch": "bun --watch src/cli.ts"
+  }
   "dependencies": {
     "@clack/core": "^1.4.2",
     "@clack/prompts": "^1.6.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up CI by running a Bun-based task matrix on PRs and main pushes. Simplifies steps, removes npm audit and caching, and keeps Node setup only for Node E2E tests.

- **Refactors**
  - Replace single job with a matrix: `audit`, `build`, `check`, `knip`, `test`, `test:node`, `security:scan` (fail-fast: false).
  - Trigger on `pull_request` and pushes to `main`.
  - Remove Bun cache, `npm audit`, and the concurrency cancellation block.
  - Standardize installs to `bun install --frozen-lockfile`; run tasks via `bun run <task>`.
  - Add `audit` and `knip` scripts; use `actions/checkout@v7` with `persist-credentials: false`; Bun 1.3.14; retain Node 22 setup for `test:node`.

<sup>Written for commit dfc1424d665bdf4dd2e18dc9162bcc44929d8da8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update CI workflow to use a matrix-driven job with Bun 1.3.14
> - Replaces sequential CI steps with a single matrix job covering `audit`, `build`, `check`, `knip`, `test`, `test:node`, and `security:scan` tasks, each running via `bun run ${{ matrix.task }}`.
> - Adds `pull_request` as a trigger alongside `push` on main.
> - Bumps Bun from 1.3.11 to 1.3.14, removes the Bun cache step, and consolidates dependency installation to `bun install --frozen-lockfile`.
> - Adds `audit` and `knip` scripts to [package.json](https://github.com/mynameistito/create-cf-token/pull/104/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to support the new matrix tasks.
> - Behavioral Change: `npm audit` is no longer run as a separate step; `knip` is now part of CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfc1424.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->