### PR TITLE
chore: changeset-add

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "build": "tsdown",
     "bump": "bun update --latest && bun add -d @types/node@~22.19.15",
     "changeset": "changeset",
+    "changeset-add": "bun run ./scripts/changeset-add.ts",
     "check": "ultracite check",
     "dev": "bun src/cli.ts",
     "fix": "ultracite fix",

--- a/scripts/changeset-add.ts
+++ b/scripts/changeset-add.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env bun
+/**
+ * Non-interactive changeset creator for AI agents
+ *
+ * Usage:
+ *   bun run ./scripts/changeset-add.ts <type> <summary>
+ *
+ * Example:
+ *   bun run ./scripts/changeset-add.ts patch "Fix clipboard timing"
+ *   bun run ./scripts/changeset-add.ts minor "Add new feature"
+ */
+
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+/** Minimal package manifest fields needed by the non-interactive changeset tool. */
+interface PackageJson {
+  /** Runtime dependencies declared by the package. */
+  dependencies?: Record<string, unknown>;
+  /** Development dependencies declared by the package. */
+  devDependencies?: Record<string, unknown>;
+  /** Package name written into Changesets frontmatter. */
+  name?: unknown;
+  /** Optional dependencies declared by the package. */
+  optionalDependencies?: Record<string, unknown>;
+  /** Peer dependencies declared by the package. */
+  peerDependencies?: Record<string, unknown>;
+}
+
+/** Semver bump types supported by Changesets. */
+type ChangesetType = "patch" | "minor" | "major";
+
+/** Runtime list used to validate command-line Changeset bump arguments. */
+const changesetTypes = ["patch", "minor", "major"] as const;
+
+/**
+ * Narrows an arbitrary CLI argument to a supported Changeset bump type.
+ *
+ * @param type - Raw type argument from the command line.
+ * @returns `true` when the value is `patch`, `minor`, or `major`.
+ */
+const isChangesetType = (type: string | undefined): type is ChangesetType =>
+  changesetTypes.includes(type as ChangesetType);
+
+/**
+ * Finds the nearest project root by walking upward until a package manifest is found.
+ *
+ * @param startDir - Directory where the search should begin.
+ * @returns The directory containing `package.json`.
+ */
+const findProjectRoot = (startDir: string) => {
+  let currentDir = startDir;
+
+  while (currentDir !== path.dirname(currentDir)) {
+    if (existsSync(path.join(currentDir, "package.json"))) {
+      return currentDir;
+    }
+
+    currentDir = path.dirname(currentDir);
+  }
+
+  if (existsSync(path.join(currentDir, "package.json"))) {
+    return currentDir;
+  }
+
+  console.error("Could not find package.json from script location");
+  process.exit(1);
+};
+
+/**
+ * Reads and parses the project's package manifest.
+ *
+ * @param packageJsonPath - Absolute path to `package.json`.
+ * @returns Parsed package metadata needed to create the changeset.
+ */
+const readPackageJson = (packageJsonPath: string) => {
+  try {
+    return JSON.parse(readFileSync(packageJsonPath, "utf-8")) as PackageJson;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error(`Failed to read package.json: ${message}`);
+    process.exit(1);
+  }
+};
+
+/**
+ * Reads the package name required by Changesets frontmatter.
+ *
+ * @param packageJson - Parsed package metadata.
+ * @returns The non-empty package name.
+ */
+const getPackageName = (packageJson: PackageJson) => {
+  if (typeof packageJson.name !== "string" || !packageJson.name.trim()) {
+    console.error("package.json must include a non-empty name field");
+    process.exit(1);
+  }
+
+  return packageJson.name;
+};
+
+/**
+ * Checks whether the package declares the Changesets CLI in any dependency block.
+ *
+ * @param packageJson - Parsed package metadata.
+ * @returns `true` when `@changesets/cli` is declared.
+ */
+const hasChangesetsCliDependency = (packageJson: PackageJson) =>
+  Boolean(
+    packageJson.dependencies?.["@changesets/cli"] ||
+    packageJson.devDependencies?.["@changesets/cli"] ||
+    packageJson.optionalDependencies?.["@changesets/cli"] ||
+    packageJson.peerDependencies?.["@changesets/cli"]
+  );
+
+/**
+ * Verifies that the Changesets CLI is both declared and installed.
+ *
+ * @param packageJson - Parsed package metadata.
+ * @param projectRoot - Root directory used to resolve installed dependencies.
+ */
+const assertChangesetsCliInstalled = (
+  packageJson: PackageJson,
+  projectRoot: string
+) => {
+  if (!hasChangesetsCliDependency(packageJson)) {
+    console.error('Missing dependency: "@changesets/cli"');
+    console.error('Install it with: bun add -d "@changesets/cli"');
+    process.exit(1);
+  }
+
+  const requireFromProject = createRequire(
+    path.join(projectRoot, "package.json")
+  );
+
+  try {
+    requireFromProject.resolve("@changesets/cli/package.json");
+  } catch {
+    console.error('Dependency "@changesets/cli" is declared but not installed');
+    console.error("Run: bun install");
+    process.exit(1);
+  }
+};
+
+/**
+ * Parses and validates the CLI bump-type argument.
+ *
+ * @param type - Raw type argument from `process.argv`.
+ * @returns A supported Changeset bump type.
+ */
+const parseChangesetType = (type: string | undefined): ChangesetType => {
+  if (isChangesetType(type)) {
+    return type;
+  }
+
+  console.error(`Invalid type: ${type}. Must be patch, minor, or major.`);
+  process.exit(1);
+};
+
+/**
+ * Creates a unique markdown filename for a new changeset.
+ *
+ * @param changesetDir - Directory where changeset files are written.
+ * @returns Absolute path for a not-yet-existing changeset file.
+ */
+const createChangesetFilename = (changesetDir: string) => {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const id = randomBytes(4).toString("hex");
+    const filename = path.join(changesetDir, `${id}.md`);
+
+    if (!existsSync(filename)) {
+      return filename;
+    }
+  }
+
+  console.error("Could not generate a unique changeset filename");
+  process.exit(1);
+};
+
+const args = process.argv.slice(2);
+
+if (args.length < 2) {
+  console.error("Usage: changeset-add.ts <type> <summary>");
+  console.error("  type: patch | minor | major");
+  console.error("  summary: Description of the change");
+  process.exit(1);
+}
+
+const [type, ...summaryParts] = args;
+const changesetType = parseChangesetType(type);
+const summary = summaryParts.join(" ");
+
+if (!summary.trim()) {
+  console.error("Summary cannot be empty");
+  process.exit(1);
+}
+
+const projectRoot = findProjectRoot(import.meta.dirname);
+const packageJson = readPackageJson(path.join(projectRoot, "package.json"));
+const packageName = getPackageName(packageJson);
+assertChangesetsCliInstalled(packageJson, projectRoot);
+
+const changesetDir = path.join(projectRoot, ".changeset");
+const filename = createChangesetFilename(changesetDir);
+const relativeFilename = path.relative(projectRoot, filename);
+
+const content = `---
+"${packageName}": ${changesetType}
+---
+
+${summary.trim()}
+`;
+
+mkdirSync(changesetDir, { recursive: true });
+writeFileSync(filename, content);
+console.log(`✓ Created changeset: ${relativeFilename}`);
+console.log(`  Package: ${packageName}`);
+console.log(`  Type: ${changesetType}`);
+console.log(`  Summary: ${summary}`);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `changeset-add` script to create changeset files non-interactively
- Adds [scripts/changeset-add.ts](https://github.com/mynameistito/create-cf-token/pull/105/files#diff-5515fb1d7c276a75376e535aa15bbb7ea3a654823a72053d51e068c8959b5863), a CLI script invoked via `bun run changeset-add <type> <summary>` that writes a `.changeset/<id>.md` file with the correct frontmatter and bump type.
- Validates that the bump type is `patch`, `minor`, or `major`, that `@changesets/cli` is declared and installed, and that the package has a non-empty name before writing.
- Generates a unique filename using random hex IDs, retrying up to 10 times before exiting with an error.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2d8652.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a non-interactive script to create Changesets and a package script to run it. This simplifies automation and ensures consistent `.changeset` entries.

- **New Features**
  - Added `scripts/changeset-add.ts` and a `changeset-add` script in `package.json`.
  - Validates `@changesets/cli` is installed, reads the package name, and finds the project root.
  - Writes `.changeset/<id>.md` with correct frontmatter and summary.

- **Migration**
  - Install the CLI if missing: `bun add -d @changesets/cli`
  - Create a changeset: `bun run changeset-add <patch|minor|major> "<summary>"`

<sup>Written for commit b2d8652b28e5bc80f037e867e8492c0bd8b0a5b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

