### PR TITLE
fix: exclude edit permissions when read-only access selected

### DIFF
--- a/.changeset/1ce9e30b.md
+++ b/.changeset/1ce9e30b.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Fix read-only scope selection including Edit-class permissions

--- a/__tests__/prompts-scope.test.ts
+++ b/__tests__/prompts-scope.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildPermissionsForSelection } from "#src/prompts.ts";
+import type { PermissionGroup, ServiceGroup } from "#src/types.ts";
+
+const ZONE_SCOPE = "com.cloudflare.api.account.zone";
+
+function perm(
+  id: string,
+  name: string,
+  scopes: string[] = [ZONE_SCOPE]
+): PermissionGroup {
+  return { description: "", id, name, scopes };
+}
+
+function dnsServiceGroup(): {
+  service: ServiceGroup;
+  readPerm: PermissionGroup;
+  writePerm: PermissionGroup;
+  editPerm: PermissionGroup;
+} {
+  const readPerm = perm("dns-read", "DNS Read");
+  const writePerm = perm("dns-write", "DNS Write");
+  const editPerm = perm("dns-edit", "DNS Edit");
+
+  return {
+    editPerm,
+    readPerm,
+    service: {
+      name: "DNS",
+      otherPerms: [editPerm],
+      perms: [readPerm, writePerm, editPerm],
+      readPerm,
+      scopes: [ZONE_SCOPE],
+      writePerm,
+    },
+    writePerm,
+  };
+}
+
+function readOnlyServiceGroup(): {
+  service: ServiceGroup;
+  readPerm: PermissionGroup;
+} {
+  const readPerm = perm("analytics-read", "DNS Analytics Read");
+
+  return {
+    readPerm,
+    service: {
+      name: "DNS Analytics",
+      otherPerms: [],
+      perms: [readPerm],
+      readPerm,
+      scopes: [ZONE_SCOPE],
+    },
+  };
+}
+
+describe("buildPermissionsForSelection", () => {
+  test("read-only excludes edit-class otherPerms", async () => {
+    const { service, readPerm } = dnsServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [service],
+      [service.name],
+      () => Promise.resolve([]),
+      () => Promise.resolve("read")
+    );
+
+    expect(result).toEqual([readPerm]);
+  });
+
+  test("read + write includes read, write, and edit permissions", async () => {
+    const { service, readPerm, writePerm, editPerm } = dnsServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [service],
+      [service.name],
+      () => Promise.resolve([]),
+      () => Promise.resolve("write")
+    );
+
+    expect(result).toEqual([readPerm, writePerm, editPerm]);
+  });
+
+  test("service with only read includes read permission", async () => {
+    const { service, readPerm } = readOnlyServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [service],
+      [service.name],
+      () => Promise.resolve([])
+    );
+
+    expect(result).toEqual([readPerm]);
+  });
+});

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1179,22 +1179,26 @@ function buildScopeOptions(scopes: ServiceGroup[]): SearchOption[] {
   });
 }
 
+type AccessLevel = "read" | "write";
+
 /**
  * For each selected scope, resolve its concrete permission groups.
  *
  * When a service has both read and write permissions, a sub-prompt asks the
- * user to choose the access level. Other permissions (e.g. edit) are included
- * automatically.
+ * user to choose the access level. Edit-class permissions in `otherPerms` are
+ * included only when the user selects read + write.
  *
  * @param scopes - All available service groups.
  * @param selected - Names of scopes the user checked in the multi-select.
  * @param reselectScopes - Re-runs scope selection when the user backs out of an access-level prompt.
+ * @param selectAccessLevel - Optional override for access-level prompts (used in unit tests).
  * @returns The resolved permission groups, or {@linkcode GO_BACK} if the user navigated back.
  */
-function buildPermissionsForSelection(
+export function buildPermissionsForSelection(
   scopes: ServiceGroup[],
   selected: string[],
-  reselectScopes: () => Promise<Backable<PermissionGroup[]>>
+  reselectScopes: () => Promise<Backable<PermissionGroup[]>>,
+  selectAccessLevel?: (service: ServiceGroup) => Promise<Backable<AccessLevel>>
 ): Promise<Backable<PermissionGroup[]>> {
   const chosen: PermissionGroup[] = [];
 
@@ -1210,9 +1214,8 @@ function buildPermissionsForSelection(
       return collect(index + 1);
     }
 
-    chosen.push(...service.otherPerms);
-
     if (!(service.readPerm && service.writePerm)) {
+      chosen.push(...service.otherPerms);
       if (service.readPerm) {
         chosen.push(service.readPerm);
       }
@@ -1222,10 +1225,12 @@ function buildPermissionsForSelection(
       return collect(index + 1);
     }
 
-    const level = await selectWithBack(`${service.name} — access level`, [
-      { label: "Read only", value: "read" },
-      { label: "Read + Write", value: "write" },
-    ]);
+    const level = selectAccessLevel
+      ? await selectAccessLevel(service)
+      : await selectWithBack(`${service.name} — access level`, [
+          { label: "Read only", value: "read" },
+          { label: "Read + Write", value: "write" },
+        ]);
 
     if (level === GO_BACK) {
       return reselectScopes();
@@ -1234,6 +1239,7 @@ function buildPermissionsForSelection(
     chosen.push(service.readPerm);
     if (level === "write") {
       chosen.push(service.writePerm);
+      chosen.push(...service.otherPerms);
     }
 
     return collect(index + 1);


### PR DESCRIPTION
## Summary
- Fix `buildPermissionsForSelection` so Edit-class `otherPerms` are only included when the user selects read + write access
- Export `buildPermissionsForSelection` with an optional test hook for access-level selection
- Add `__tests__/prompts-scope.test.ts` covering read-only, read+write, and read-only service cases

Closes #108

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] `bun test` passes (69 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix read-only scope selection so Edit-class permissions in `otherPerms` are excluded; they’re only added when the user selects read + write. Export `buildPermissionsForSelection` with an optional access-level hook and add unit tests for read-only, read + write, and read-only service cases.

<sup>Written for commit d650395469591faae20051be6a1ced992ea2e978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `buildPermissionsForSelection` to exclude edit-class permissions when read-only access is selected
> When a service exposes both read and write permissions, `otherPerms` (which may include edit-class permissions) were previously added regardless of the chosen access level. Now `otherPerms` are only included when the user selects "Read + Write"; selecting "Read only" omits them. Services that lack a full read/write pair retain the existing behavior of always including `otherPerms`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d650395.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->