### PR TITLE
chore: remove unused showNote export

### DIFF
--- a/.changeset/4a07edff.md
+++ b/.changeset/4a07edff.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Remove unused showNote export from prompts module

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1349,16 +1349,6 @@ export const logMessage = {
 };
 
 /**
- * Display a clack note box with a title.
- *
- * @param message - The note body.
- * @param title - The note heading.
- */
-export function showNote(message: string, title: string): void {
-  note(message, title);
-}
-
-/**
  * Display a clack outro message signalling completion.
  *
  * @param message - The outro text.


### PR DESCRIPTION
## Summary

- Remove the unused showNote export from src/prompts.ts (dead code flagged by knip)
- Closes #115

## Test plan

- [x] un run typecheck
- [x] un run check
- [x] un test (66 pass on main; local run may include unrelated untracked tests)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `showNote` export from `src/prompts.ts` to clean up dead code flagged by `knip`; adds a patch changeset for `create-cf-token`. No functional changes.

<sup>Written for commit 61ef64bea05e6d3855a6b4d7a64270a2c5690467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `showNote` export from prompts module
> Deletes the `showNote` function from [src/prompts.ts](https://github.com/mynameistito/create-cf-token/pull/119/files#diff-0f0b37407b21be6434ac29c4b75a5a1c31ade0668c1afafa267cba4efc13aba9), which was a thin wrapper around `note()` and was not used anywhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61ef64b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->