### PR TITLE
chore: add knip configuration so CI knip job passes

### DIFF
--- a/.changeset/b0875add.md
+++ b/.changeset/b0875add.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Add knip configuration so CI knip job passes

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": ["__tests__/**/*.test.ts", "__tests__/helpers/**/*.ts"],
+  "project": ["src/**/*.ts", "scripts/**/*.ts", "__tests__/**/*.ts"],
+  "ignoreDependencies": ["bun-types"],
+  "ignoreIssues": {
+    "src/prompts.ts": ["exports"]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `knip.json` with test file entry points and project globs so `__tests__/` is not flagged as unused
- Ignore `bun-types` triple-slash references (provided via `@types/bun`)
- Temporarily ignore `showNote` unused export (addressed in #115)

Closes #109

## Test plan

- [x] `bun run knip` exits 0
- [x] `bun run check` exits 0

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add knip.json to configure test entry points and project globs so `__tests__/` files aren’t flagged as unused, making the CI `knip` job pass. Also ignore `bun-types` triple-slash references (provided via `@types/bun`) and temporarily silence the `showNote` unused export in `src/prompts.ts`.

<sup>Written for commit 0776edec0f2319f3c405e2cb32b1346f3ce78109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add knip configuration to make CI knip job pass for `create-cf-token`
> Adds [knip.json](https://github.com/mynameistito/create-cf-token/pull/120/files#diff-5086ee3d4f07acf8704cd800423a4681bb25515a3f704afeebda27281a32eea3) to configure entry and project globs for source, scripts, and test files, ignores `bun-types` as an unlisted dependency, and suppresses a false-positive `exports` issue on `src/prompts.ts`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0776ede.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->