### PR TITLE
test: add unit tests for buildPermissionsForSelection

### DIFF
--- a/.changeset/ff3ae9fe.md
+++ b/.changeset/ff3ae9fe.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Add unit tests for scope permission selection logic

--- a/__tests__/prompts-scope.test.ts
+++ b/__tests__/prompts-scope.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildPermissionsForSelection, GO_BACK } from "#src/prompts.ts";
+import type { PermissionGroup, ServiceGroup } from "#src/types.ts";
+
+const ZONE_SCOPE = "com.cloudflare.api.account.zone";
+
+function perm(
+  id: string,
+  name: string,
+  scopes: string[] = [ZONE_SCOPE]
+): PermissionGroup {
+  return { description: "", id, name, scopes };
+}
+
+function dnsServiceGroup(): {
+  service: ServiceGroup;
+  readPerm: PermissionGroup;
+  writePerm: PermissionGroup;
+  editPerm: PermissionGroup;
+} {
+  const readPerm = perm("dns-read", "DNS Read");
+  const writePerm = perm("dns-write", "DNS Write");
+  const editPerm = perm("dns-edit", "DNS Edit");
+
+  return {
+    editPerm,
+    readPerm,
+    service: {
+      name: "DNS",
+      otherPerms: [editPerm],
+      perms: [readPerm, writePerm, editPerm],
+      readPerm,
+      scopes: [ZONE_SCOPE],
+      writePerm,
+    },
+    writePerm,
+  };
+}
+
+function readOnlyServiceGroup(): {
+  service: ServiceGroup;
+  readPerm: PermissionGroup;
+} {
+  const readPerm = perm("analytics-read", "DNS Analytics Read");
+
+  return {
+    readPerm,
+    service: {
+      name: "DNS Analytics",
+      otherPerms: [],
+      perms: [readPerm],
+      readPerm,
+      scopes: [ZONE_SCOPE],
+    },
+  };
+}
+
+describe("buildPermissionsForSelection", () => {
+  test("read-only excludes edit-class otherPerms", async () => {
+    const { service, readPerm } = dnsServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [service],
+      [service.name],
+      () => Promise.resolve([]),
+      () => Promise.resolve("read")
+    );
+
+    expect(result).toEqual([readPerm]);
+  });
+
+  test("read + write includes read, write, and edit permissions", async () => {
+    const { service, readPerm, writePerm, editPerm } = dnsServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [service],
+      [service.name],
+      () => Promise.resolve([]),
+      () => Promise.resolve("write")
+    );
+
+    expect(result).toEqual([readPerm, writePerm, editPerm]);
+  });
+
+  test("service with only read includes read permission", async () => {
+    const { service, readPerm } = readOnlyServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [service],
+      [service.name],
+      () => Promise.resolve([])
+    );
+
+    expect(result).toEqual([readPerm]);
+  });
+
+  test("skips unknown scope names", async () => {
+    const { service, readPerm } = readOnlyServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [service],
+      ["Missing Service", service.name],
+      () => Promise.resolve([]),
+      () => Promise.resolve("read")
+    );
+
+    expect(result).toEqual([readPerm]);
+  });
+
+  test("resolves multiple selected services in order", async () => {
+    const dns = dnsServiceGroup();
+    const analytics = readOnlyServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [dns.service, analytics.service],
+      [dns.service.name, analytics.service.name],
+      () => Promise.resolve([]),
+      () => Promise.resolve("read")
+    );
+
+    expect(result).toEqual([dns.readPerm, analytics.readPerm]);
+  });
+
+  test("returns reselectScopes result when access level is GO_BACK", async () => {
+    const { service } = dnsServiceGroup();
+    const reselected = [perm("reselected", "Re-selected")];
+    const result = await buildPermissionsForSelection(
+      [service],
+      [service.name],
+      () => Promise.resolve(reselected),
+      () => Promise.resolve(GO_BACK)
+    );
+
+    expect(result).toEqual(reselected);
+  });
+});

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1179,22 +1179,26 @@ function buildScopeOptions(scopes: ServiceGroup[]): SearchOption[] {
   });
 }
 
+type AccessLevel = "read" | "write";
+
 /**
  * For each selected scope, resolve its concrete permission groups.
  *
  * When a service has both read and write permissions, a sub-prompt asks the
- * user to choose the access level. Other permissions (e.g. edit) are included
- * automatically.
+ * user to choose the access level. Edit-class permissions in `otherPerms` are
+ * included only when the user selects read + write.
  *
  * @param scopes - All available service groups.
  * @param selected - Names of scopes the user checked in the multi-select.
  * @param reselectScopes - Re-runs scope selection when the user backs out of an access-level prompt.
+ * @param selectAccessLevel - Optional override for access-level prompts (used in unit tests).
  * @returns The resolved permission groups, or {@linkcode GO_BACK} if the user navigated back.
  */
-function buildPermissionsForSelection(
+export function buildPermissionsForSelection(
   scopes: ServiceGroup[],
   selected: string[],
-  reselectScopes: () => Promise<Backable<PermissionGroup[]>>
+  reselectScopes: () => Promise<Backable<PermissionGroup[]>>,
+  selectAccessLevel?: (service: ServiceGroup) => Promise<Backable<AccessLevel>>
 ): Promise<Backable<PermissionGroup[]>> {
   const chosen: PermissionGroup[] = [];
 
@@ -1210,9 +1214,8 @@ function buildPermissionsForSelection(
       return collect(index + 1);
     }
 
-    chosen.push(...service.otherPerms);
-
     if (!(service.readPerm && service.writePerm)) {
+      chosen.push(...service.otherPerms);
       if (service.readPerm) {
         chosen.push(service.readPerm);
       }
@@ -1222,10 +1225,12 @@ function buildPermissionsForSelection(
       return collect(index + 1);
     }
 
-    const level = await selectWithBack(`${service.name} — access level`, [
-      { label: "Read only", value: "read" },
-      { label: "Read + Write", value: "write" },
-    ]);
+    const level = selectAccessLevel
+      ? await selectAccessLevel(service)
+      : await selectWithBack(`${service.name} — access level`, [
+          { label: "Read only", value: "read" },
+          { label: "Read + Write", value: "write" },
+        ]);
 
     if (level === GO_BACK) {
       return reselectScopes();
@@ -1234,6 +1239,7 @@ function buildPermissionsForSelection(
     chosen.push(service.readPerm);
     if (level === "write") {
       chosen.push(service.writePerm);
+      chosen.push(...service.otherPerms);
     }
 
     return collect(index + 1);


### PR DESCRIPTION
## Summary

- Add \__tests__/prompts-scope.test.ts\ with six unit tests covering read-only vs read+write permission resolution, unknown scopes, multi-service selection, and GO_BACK reselection.
- Export \uildPermissionsForSelection\ with an optional \selectAccessLevel\ hook so access-level prompts can be stubbed in tests.
- Fix read-only scope selection so edit-class \otherPerms\ are excluded (included only when the user selects read + write).

Closes #113

## Overlap with #118

PR #118 (\ix/improve-003-read-only-scope\) is still open and implements the same \uildPermissionsForSelection\ fix plus three core tests. This PR supersedes that work with the same behavioral fix and a broader test suite (unknown scopes, multi-service, GO_BACK). If both land, close #118 as duplicate.

## Test plan

- [x] \un run typecheck\
- [x] \un run check\
- [x] \un test\ (72 tests, including 6 new prompts-scope tests)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for scope permission selection and exported `buildPermissionsForSelection` with an optional `selectAccessLevel` hook for testing (closes #113).

- **Bug Fixes**
  - Read-only scope selection no longer includes edit-class `otherPerms`.

<sup>Written for commit 5bcb0435cc8d05a9f2b4fa11f8e77351d32c0655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for `buildPermissionsForSelection` and exclude `otherPerms` on read-only selection
> - Exports `buildPermissionsForSelection` from [prompts.ts](https://github.com/mynameistito/create-cf-token/pull/121/files#diff-0f0b37407b21be6434ac29c4b75a5a1c31ade0668c1afafa267cba4efc13aba9) and adds an optional `selectAccessLevel` override parameter to support testing without interactive prompts.
> - Changes permission inclusion logic: `otherPerms` (edit-class permissions) are now excluded when a user selects read-only for services that have both read and write permissions; they are only included when write is selected or the service has no read/write permissions.
> - Adds a new test suite in [prompts-scope.test.ts](https://github.com/mynameistito/create-cf-token/pull/121/files#diff-3c2990e98aceada60814158616066128483b8f382b7e1a376a27aa878230f361) covering six scenarios: read-only exclusion, read+write inclusion, read-only services, unknown service names, multi-service ordering, and `GO_BACK` handling.
> - Behavioral Change: callers that previously received `otherPerms` for read-only selections on services with both read and write will no longer receive those permissions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bcb043.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->