### PR TITLE
docs: sync AGENTS and CONTRIBUTING to current architecture

### DIFF
--- a/.changeset/b9268623.md
+++ b/.changeset/b9268623.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Sync AGENTS.md and CONTRIBUTING to current codebase

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,10 @@ CLI tool for creating Cloudflare API tokens via interactive guided prompts. Type
 .
 ├── src/              # All source code (8 files)
 │   ├── cli.ts        # Thin bin entry, imports main() from index.ts
-│   ├── index.ts      # CLI orchestrator + retry logic (~550 lines)
+│   ├── index.ts      # CLI orchestrator (~290 lines)
 │   ├── api.ts        # Cloudflare REST API wrappers (raw fetch)
 │   ├── errors.ts     # TaggedError hierarchy (better-result)
-│   ├── permissions.ts # groupByService, extractFailedPerm
+│   ├── permissions.ts # groupByService
 │   ├── prompts.ts    # @clack/prompts interactive UI
 │   ├── types.ts      # Shared interfaces
 │   └── colour.ts     # ANSI color constants (British spelling intentional)
@@ -39,41 +39,38 @@ CLI tool for creating Cloudflare API tokens via interactive guided prompts. Type
 | Add/modify CLI prompts     | `src/prompts.ts`     | Only module that imports `@clack/prompts`          |
 | Change token creation flow | `src/index.ts`       | `main()` orchestrates everything                   |
 | Add shared types           | `src/types.ts`       | API response types, input types                    |
-| Permission grouping logic  | `src/permissions.ts` | `groupByService()`, `extractFailedPerm()`          |
+| Permission grouping logic  | `src/permissions.ts` | `groupByService()`                                 |
 | Add CLI flags/args         | `src/index.ts`       | `handleFlags()` parses --help, --version           |
 | Change build config        | `tsdown.config.ts`   | 6 entry points, shebang banner, version define     |
 
 ## CODE MAP
 
-| Symbol                      | Type     | Location             | Role                                               |
-| --------------------------- | -------- | -------------------- | -------------------------------------------------- |
-| `main()`                    | function | `src/index.ts`       | CLI orchestrator                                   |
-| `handleFlags()`             | function | `src/index.ts`       | --help/--version parser, uses console.log directly |
-| `handleApiError()`          | function | `src/index.ts`       | Never-returning error handler                      |
-| `buildPolicies()`           | function | `src/index.ts`       | Constructs API policy objects from selections      |
-| `run()`                     | function | `src/cli.ts`         | Entry guard with `import.meta.main` check          |
-| `cfGet()`                   | function | `src/api.ts`         | Internal GET helper (not exported)                 |
-| `getUser()`                 | function | `src/api.ts`         | GET /user                                          |
-| `getAccounts()`             | function | `src/api.ts`         | GET /accounts                                      |
-| `getPermissionGroups()`     | function | `src/api.ts`         | GET /user/tokens/permission_groups                 |
-| `createToken()`             | function | `src/api.ts`         | POST /user/tokens                                  |
-| `CloudflareApiError`        | class    | `src/errors.ts`      | Base TaggedError                                   |
-| `TokenCreationError`        | class    | `src/errors.ts`      | Token create failed                                |
-| `RestrictedPermissionError` | class    | `src/errors.ts`      | Restricted permission exclusion                    |
-| `TokenDeletionError`        | class    | `src/errors.ts`      | Token delete failed                                |
-| `groupByService()`          | function | `src/permissions.ts` | Groups perms by service                            |
-| `extractFailedPerm()`       | function | `src/permissions.ts` | Error message helper                               |
+| Symbol                  | Type     | Location             | Role                                               |
+| ----------------------- | -------- | -------------------- | -------------------------------------------------- |
+| `main()`                | function | `src/index.ts`       | CLI orchestrator                                   |
+| `handleFlags()`         | function | `src/index.ts`       | --help/--version parser, uses console.log directly |
+| `handleApiError()`      | function | `src/index.ts`       | Never-returning error handler                      |
+| `buildPolicies()`       | function | `src/index.ts`       | Constructs API policy objects from selections      |
+| `run()`                 | function | `src/cli.ts`         | Entry guard with `import.meta.main` check          |
+| `cfGet()`               | function | `src/api.ts`         | Internal GET helper (not exported)                 |
+| `getUser()`             | function | `src/api.ts`         | GET /user                                          |
+| `getAccounts()`         | function | `src/api.ts`         | GET /accounts                                      |
+| `getPermissionGroups()` | function | `src/api.ts`         | GET /user/tokens/permission_groups                 |
+| `createToken()`         | function | `src/api.ts`         | POST /user/tokens                                  |
+| `CloudflareApiError`    | class    | `src/errors.ts`      | TaggedError for failed Cloudflare API requests     |
+| `groupByService()`      | function | `src/permissions.ts` | Groups perms by service                            |
 
 ## CONVENTIONS
 
 - **Error handling**: `better-result` TaggedError everywhere. API functions return `Result<T, E>`, never throw. `handleApiError` in index.ts is `never`-returning. Pattern-match with `matchError()` at call sites.
 - **UI isolation**: Only `prompts.ts` imports `@clack/prompts`. Other modules never touch the terminal. `colour.ts` provides raw ANSI codes, not clack abstractions. `handleFlags()` uses `console.log` directly for --help/--version (acceptable exception).
 - **No SDK**: Cloudflare API called via raw `fetch`. No `@cloudflare/workers-types` or CF SDK.
+- **Auth**: Bearer token via `CF_API_TOKEN` env var or interactive prompt. `api.ts` sends `Authorization: Bearer <token>` — never Global API Key or email auth.
 - **Build**: `tsdown` (Rolldown-based). TypeScript is type-check only (`noEmit: true`). No tsc in build pipeline. Shebang injected via `banner` function (keyed on `chunk.fileName.startsWith("cli")`). Do **not** add shebang to `src/cli.ts`.
 - **Module resolution**: `module: "Preserve"`, `moduleResolution: "bundler"`. `.ts` extension imports allowed. All internal imports use `#src/*` package.json imports alias.
-- **Type-checking**: `tsgo --noEmit` (TypeScript 7 native Go rewrite), not `tsc`.
+- **Type-checking**: `tsgo --noEmit` (TypeScript 7 native Go rewrite), not `tsc`. Runs in pre-commit hooks, not CI.
 - **Linting**: Ultracite (Biome preset) via `bun x ultracite fix`/`check`. Pre-commit hook auto-fixes + stages via Lefthook. Claude Code post-edit hook skips `noUnusedImports`.
-- **Process env**: `CF_EMAIL` pre-fills email prompt. `CF_API_TOKEN` used for API auth (not committed). `CF_API_BASE_URL` overridable for testing.
+- **Process env**: `CF_API_TOKEN` for API auth (not committed). `CF_API_BASE_URL` overridable for testing.
 - **Version**: `process.env.npm_package_version` replaced at build time via tsdown `define`. Fallback `"0.0.0"` is dead code in published builds.
 - **Test runner**: Bun test (`bun:test`). No Vitest/Jest. E2E tests use subprocess spawning, unit tests use `Bun.serve()` mock HTTP server.
 
@@ -105,10 +102,8 @@ bun run release             # Build + publish to npm
 
 ## NOTES
 
-- **No tests in CI**. CI runs typecheck, lint, build, audit — but not `bun test`. Tests are local-only.
 - **Node version mismatch**: CI tests on Node 22, releases on Node 24.
-- `CF_EMAIL` env var pre-fills the email prompt.
-- `process.env.CF_API_TOKEN` is runtime auth (not committed).
+- `process.env.CF_API_TOKEN` is runtime auth (not committed). Requires a scoped token with `User Details:Read`, `User API Tokens:Edit`, and `Account Settings:Read`.
 - `process.env.CF_API_BASE_URL` overrides API base URL (used by tests).
 - Pre-commit hook auto-fixes + stages formatting via Lefthook.
 - Preview packages published on every PR via `pkg-pr-new` (`bunx create-cf-token@pr-N`).
@@ -120,9 +115,9 @@ bun run release             # Build + publish to npm
 
 ## CI PIPELINE
 
-| Workflow              | Trigger                | Key Steps                                    |
-| --------------------- | ---------------------- | -------------------------------------------- |
-| `ci.yml`              | PR + push to main      | typecheck, lint, build, bun audit, npm audit |
-| `release.yml`         | Push to main           | changeset version, publish with provenance   |
-| `publish-preview.yml` | PR (not forks)         | `pkg-pr-new` preview publish                 |
-| `codeql.yml`          | Weekly (Mon 07:23 UTC) | Security scanning (extended queries)         |
+| Workflow              | Trigger                | Key Steps                                                                   |
+| --------------------- | ---------------------- | --------------------------------------------------------------------------- |
+| `ci.yml`              | PR + push to main      | Matrix: audit, build, check, knip, test, test:node, security:scan (Node 22) |
+| `release.yml`         | Push to main           | changeset version, publish with provenance                                  |
+| `publish-preview.yml` | PR (not forks)         | `pkg-pr-new` preview publish                                                |
+| `codeql.yml`          | Weekly (Mon 07:23 UTC) | Security scanning (extended queries)                                        |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for taking the time to contribute!
 ## Prerequisites
 
 - [Bun](https://bun.sh) ≥ 1.0.0 **or** Node.js ≥ 22.0.0
-- A Cloudflare **Global API Key** and account email to test the tool against a real account
+- A scoped Cloudflare **API token** (`CF_API_TOKEN`) with `User Details:Read`, `User API Tokens:Edit`, and `Account Settings:Read` permissions to test against a real account
 
 ## Setup
 
@@ -99,12 +99,17 @@ Use short, imperative commit messages (e.g. `fix: handle missing scope in retry`
 
 ## CI
 
-CI runs on every push and PR to `main`:
+CI runs on every push and PR to `main` as a matrix of jobs (Node 22, Bun 1.3.14):
 
-1. **check** — typecheck + lint
+1. **audit** — `bun audit`
 2. **build** — production build via tsdown
+3. **check** — lint and format via Ultracite
+4. **knip** — unused export detection
+5. **test** — `bun test`
+6. **test:node** — build + Node E2E test against `dist/cli.mjs`
+7. **security:scan** — security regression tests
 
-All jobs must pass for a PR to be mergeable.
+All matrix jobs must pass for a PR to be mergeable. Type-checking (`bun run typecheck`) runs in the pre-commit hook, not CI.
 
 ## Release Process
 

--- a/__tests__/AGENTS.md
+++ b/__tests__/AGENTS.md
@@ -9,8 +9,8 @@ Bun test suite. 10 test files + 1 shared helper. Uses `bun:test` exclusively —
 | File                          | Purpose                                                                                                                     |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `api.test.ts`                 | Unit tests for all `api.ts` functions. Uses `Bun.serve()` mock server on random port. 13 test cases, most in `api.test.ts`. |
-| `permissions.test.ts`         | Unit tests for `groupByService` and `extractFailedPerm`.                                                                    |
-| `errors.test.ts`              | Unit tests for `TaggedError` subclass construction. Uses `test.concurrent`.                                                 |
+| `permissions.test.ts`         | Unit tests for `groupByService`.                                                                                            |
+| `errors.test.ts`              | Unit tests for `CloudflareApiError` construction. Uses `test.concurrent`.                                                   |
 | `build-policies.test.ts`      | Unit tests for `buildPolicies` pure function. Uses `test.concurrent`.                                                       |
 | `handle-cli-error.test.ts`    | Unit tests for `handleCliError` using `spyOn` mocking.                                                                      |
 | `cli.run.test.ts`             | Module-level mock test using `mock.module()` (Bun-specific). Imports `#src/cli.ts` with mocked `#src/index.ts`.             |
@@ -29,11 +29,11 @@ Bun test suite. 10 test files + 1 shared helper. Uses `bun:test` exclusively —
 - **Import style**: All test imports use `#src/*` package.json imports alias with `.ts` extensions (same as production code).
 - **Fixture style**: Test data defined as inline constants (`USER_FIXTURE`, `ACCOUNTS_FIXTURE`, etc.) at top of each file. No external fixture files.
 - **Result assertions**: Uses `better-result` `Result` type with `result.isOk()` / `result.isErr()` guard pattern, not `.unwrap()`.
-- **Node E2E exclusion**: `cli.node.e2e.test.ts` is excluded from default `bun test` via `bunfig.toml` (`exclude = ["**/*.node.e2e.test.ts"]`). Runs via `bun run test:node` which builds first.
+- **Node E2E**: `bunfig.toml` excludes `**/*.node.test.ts` from default `bun test`. `cli.node.e2e.test.ts` is included in default `bun test` (with `test.skipIf` when `dist/` is missing) and also runs via `bun run test:node`, which builds first.
 - **Lint suppressions**: `biome-ignore` comments are always annotated with a reason.
 
 ## NOTES
 
 - `prompts.ts` has no direct unit test coverage. Only exercised indirectly through E2E subprocess tests.
-- CI does not run `bun test`. Tests are local-only.
+- CI runs `bun test` and `bun run test:node` as matrix jobs.
 - `bunfig.toml` enables coverage by default (`coverage = true`), outputs to `.coverage/`.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -9,20 +9,19 @@ CLI runtime modules. `main()` in `index.ts` orchestrates the full token-creation
 | File             | Purpose                                                                                                                                                                                   |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `index.ts`       | Entry point. `main()` orchestrates the full flow. `handleApiError` (never-returning), `handleFlags`, `handleCliError`, `buildPolicies`.                                                   |
-| `api.ts`         | Cloudflare REST API wrappers. All return `Result<T, E>` via `Result.tryPromise`. Internal `cfGet` helper. Credentials passed as `(email, apiKey)` — never stored globally.                |
-| `errors.ts`      | `TaggedError` subtypes: `CloudflareApiError`, `TokenCreationError`, `RestrictedPermissionError`, `TokenDeletionError`.                                                                    |
+| `api.ts`         | Cloudflare REST API wrappers. All return `Result<T, E>` via `Result.tryPromise`. Internal `cfGet` helper. Bearer token passed as `apiToken` — never stored globally.                      |
+| `errors.ts`      | `CloudflareApiError` TaggedError for failed Cloudflare API requests.                                                                                                                      |
 | `prompts.ts`     | All `@clack/prompts` interaction. Internal `check()` guard for cancellation. Largest file, contains all interactive logic.                                                                |
-| `permissions.ts` | `groupByService` (PermissionGroup[] → ServiceGroup[]), `extractFailedPerm` (regex extraction from CF errors).                                                                             |
+| `permissions.ts` | `groupByService` (PermissionGroup[] → ServiceGroup[]).                                                                                                                                    |
 | `types.ts`       | Shared interfaces: `Account`, `PermissionGroup`, `ServiceGroup`, `Policy`, `UserInfo`.                                                                                                    |
 | `colour.ts`      | ANSI color constants object (British spelling intentional). Default export of 5 color codes.                                                                                              |
 | `cli.ts`         | Thin bin entry (26 lines). Imports `main`, `handleFlags`, `handleCliError` from `#src/index.ts`. Guards execution with `import.meta.main`. No shebang — injected at build time by tsdown. |
 
 ## CONVENTIONS
 
-- **Error handling**: All API errors flow as `TaggedError` subtypes through `Result`. Pattern-match with `matchError` at call sites. `UnhandledException` from `better-result` wraps unknowns.
-- **API layer**: `api.ts` is the only module that calls `fetch`. Every exported function returns `Result<T, CloudflareApiError | UnhandledException>` (or narrower). Credentials passed as `(email, apiKey)` — never stored globally.
+- **Error handling**: All API errors flow as `CloudflareApiError` through `Result`. Pattern-match with `matchError` at call sites. `UnhandledException` from `better-result` wraps unknowns.
+- **API layer**: `api.ts` is the only module that calls `fetch`. Every exported function returns `Result<T, CloudflareApiError | UnhandledException>`. Bearer token passed as `apiToken` — never stored globally.
 - **UI isolation**: All `@clack/prompts` calls live in `prompts.ts`. Other modules never import from `@clack/prompts`. `colour.ts` provides raw ANSI codes, not clack abstractions.
-- **Retry loop**: Token creation retries up to 50 times, auto-excluding `RestrictedPermissionError` permissions. The `excluded` Set tracks what was dropped.
 - **Permission scoping**: Permissions are split into user/account/zone buckets by checking `scopes` array for `com.cloudflare.api.user`, `com.cloudflare.api.account`, `com.cloudflare.api.account.zone`.
 - **Import style**: All internal imports use `#src/*` package.json imports alias with `.ts` extensions. No relative `../` paths.
 - **Version**: `process.env.npm_package_version` is replaced at build time by tsdown `define`. The `"0.0.0"` fallback is dead code in published builds.


### PR DESCRIPTION
## Summary

- Sync `AGENTS.md`, `CONTRIBUTING.md`, `src/AGENTS.md`, and `__tests__/AGENTS.md` to the current codebase
- Document Bearer `CF_API_TOKEN` auth only (remove `CF_EMAIL`, Global API Key, and stale retry/`extractFailedPerm` references)
- Update CI docs to match the `ci.yml` matrix (audit, build, check, knip, test, test:node, security:scan)
- Document only `CloudflareApiError` in the error type map (matches `src/errors.ts` on main)

Closes #110

## Test plan

- [x] `bun run check` passes
- [x] No `CF_EMAIL` or Global API Key references in scoped doc files
- [x] Changeset added


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync docs to the current CLI architecture and CI setup. Moves all auth docs to bearer `CF_API_TOKEN`, drops Global API Key/email, and aligns error docs to `CloudflareApiError` only. Closes #110.

- **Refactors**
  - Updated `AGENTS.md`, `CONTRIBUTING.md`, `src/AGENTS.md`, and `__tests__/AGENTS.md` to match the codebase; removed retry/`extractFailedPerm` references.
  - Auth now documents only bearer `CF_API_TOKEN`; removed `CF_EMAIL` and Global API Key.
  - CI docs now mirror `ci.yml` matrix: audit, build, check, knip, test, test:node, security:scan (Node 22).
  - Error types documented only list `CloudflareApiError`; test notes reflect CI running `bun test` and `test:node`.

<sup>Written for commit 4c9988f723453a97d077a11834d7f67d72bd4d39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync AGENTS.md and CONTRIBUTING.md docs to current codebase architecture
> Updates developer-facing documentation across [AGENTS.md](https://github.com/mynameistito/create-cf-token/pull/122/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9), [CONTRIBUTING.md](https://github.com/mynameistito/create-cf-token/pull/122/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055), [src/AGENTS.md](https://github.com/mynameistito/create-cf-token/pull/122/files#diff-3362030dfe232705631df76d745905dabbe350cde1c448e0f6ccbaa1eeb1ef9c), and [__tests__/AGENTS.md](https://github.com/mynameistito/create-cf-token/pull/122/files#diff-08a76167b56a181ade19bbefd8e21043375976a011cde2b03a7f4c35e09b0746) to reflect the current state of the codebase.
>
> - Replaces Global API Key + email auth prerequisite with a scoped `CF_API_TOKEN` bearer token and documents required permission scopes
> - Corrects CI pipeline description to a matrix of jobs (`audit`, `build`, `check`, `knip`, `test`, `test:node`, `security:scan`) on Node 22 and Bun 1.3.14
> - Removes references to deleted helpers (`extractFailedPerm`, several `TaggedError` subclasses) and notes that `api.ts` now uses bearer token auth instead of email/API key
> - Clarifies that type-checking runs in pre-commit hooks rather than CI
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c9988f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->