### PR TITLE
fix: harden Cloudflare API error response parsing

### DIFF
--- a/.changeset/e5f572ed.md
+++ b/.changeset/e5f572ed.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Harden Cloudflare API error response parsing for malformed bodies

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -228,3 +228,59 @@ describe("createToken — API error", () => {
     }
   });
 });
+
+describe("API error parsing — malformed HTML", () => {
+  let server: TestServer;
+
+  beforeAll(() => {
+    server = startTestServer({
+      "/user": {
+        rawBody: "<html><body>Bad Gateway</body></html>",
+        status: 502,
+      },
+    });
+    process.env.CF_API_BASE_URL = server.baseUrl;
+  });
+
+  afterAll(() => {
+    server.stop();
+    delete process.env.CF_API_BASE_URL;
+  });
+
+  test("returns Err(CloudflareApiError) for non-JSON 502 body", async () => {
+    const result = await getUser("my-token");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && CloudflareApiError.is(result.error)) {
+      expect(result.error.messages).toEqual([
+        "HTTP 502: Invalid JSON response",
+      ]);
+    }
+  });
+});
+
+describe("API error parsing — missing errors array", () => {
+  let server: TestServer;
+
+  beforeAll(() => {
+    server = startTestServer({
+      "/user": {
+        body: { result: null, success: false },
+        status: 400,
+      },
+    });
+    process.env.CF_API_BASE_URL = server.baseUrl;
+  });
+
+  afterAll(() => {
+    server.stop();
+    delete process.env.CF_API_BASE_URL;
+  });
+
+  test("returns Err(CloudflareApiError) with empty messages", async () => {
+    const result = await getUser("my-token");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && CloudflareApiError.is(result.error)) {
+      expect(result.error.messages).toEqual([]);
+    }
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,49 @@ import type {
 
 const TRAILING_SLASH_REGEX = /\/+$/u;
 
+/** Shape of a Cloudflare API v4 JSON envelope. */
+interface CfApiEnvelope<T> {
+  success: boolean;
+  result: T;
+  errors?: { message: string }[];
+}
+
+/**
+ * Safely parse a JSON string, returning `null` on failure instead of throwing.
+ *
+ * @param text - Raw response body text.
+ * @returns The parsed object cast to `T`, or `null` if parsing fails.
+ */
+function tryParseJson<T>(text: string): T | null {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a Cloudflare API response body and extract `result` on success.
+ *
+ * @throws {CloudflareApiError} When the body is not JSON or `success` is false.
+ */
+function parseCfResult<T>(text: string, path: string, res: Response): T {
+  const json = tryParseJson<CfApiEnvelope<T>>(text);
+  if (!json) {
+    const message = res.ok
+      ? "Invalid JSON response"
+      : `HTTP ${res.status}: Invalid JSON response`;
+    throw new CloudflareApiError({ messages: [message], path });
+  }
+  if (!json.success) {
+    throw new CloudflareApiError({
+      messages: (json.errors ?? []).map((e) => e.message),
+      path,
+    });
+  }
+  return json.result;
+}
+
 /**
  * Resolve the Cloudflare API base URL.
  * Reads `CF_API_BASE_URL` from the environment; falls back to the public API.
@@ -56,18 +99,8 @@ function cfGet<T>(
       const res = await fetch(`${cfApiBase()}${path}`, {
         headers: authHeaders(apiToken),
       });
-      const json = (await res.json()) as {
-        success: boolean;
-        result: T;
-        errors: { message: string }[];
-      };
-      if (!json.success) {
-        throw new CloudflareApiError({
-          messages: json.errors.map((e) => e.message),
-          path,
-        });
-      }
-      return json.result;
+      const text = await res.text();
+      return parseCfResult<T>(text, path, res);
     },
   });
 }
@@ -136,18 +169,8 @@ function cfPost<T>(
         },
         method: "POST",
       });
-      const json = (await res.json()) as {
-        success: boolean;
-        result: T;
-        errors: { message: string }[];
-      };
-      if (!json.success) {
-        throw new CloudflareApiError({
-          messages: json.errors.map((e) => e.message),
-          path,
-        });
-      }
-      return json.result;
+      const text = await res.text();
+      return parseCfResult<T>(text, path, res);
     },
   });
 }


### PR DESCRIPTION
## Summary

- Add 	ryParseJson and parseCfResult helpers in src/api.ts to safely parse Cloudflare API response bodies
- Update cfGet and cfPost to read response text first and guard missing rrors arrays with (json.errors ?? [])
- Return CloudflareApiError with HTTP status context for non-JSON error pages (e.g. 502 HTML)
- Add unit tests for malformed HTML and missing rrors array responses

Closes #114

## Test plan

- [x] un run typecheck
- [x] un run check
- [x] un test (68 tests, 0 failures)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Cloudflare API error parsing to handle non-JSON bodies and missing errors arrays without crashing. Improves error messages with HTTP status and keeps `cfGet`/`cfPost` resilient.

- **Bug Fixes**
  - Added `tryParseJson` and `parseCfResult` to safely parse responses and extract `result`.
  - Updated `cfGet`/`cfPost` to read response text and handle `(json.errors ?? [])`.
  - Return `CloudflareApiError` with HTTP status for non-JSON error pages (e.g., 502 HTML).
  - Added tests for malformed HTML and missing `errors`.

<sup>Written for commit 2bd35d4849725298c1b04d837977fe79e17e4456. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden Cloudflare API error response parsing for malformed or non-JSON bodies
> - Adds `tryParseJson` helper in [src/api.ts](https://github.com/mynameistito/create-cf-token/pull/123/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700) that returns `null` on invalid JSON instead of throwing.
> - Adds `parseCfResult` to centralize envelope parsing: returns `CloudflareApiError` with `["HTTP <status>: Invalid JSON response"]` for non-JSON bodies, and extracts `errors` (or `[]` if absent) for failed envelopes.
> - Updates `cfGet` and `cfPost` to read responses as text and delegate to `parseCfResult` instead of calling `res.json()` directly.
> - Behavioral Change: previously, a non-JSON response body or missing `errors` array would throw an unhandled exception; now both cases return a structured `CloudflareApiError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bd35d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->