### PR TITLE
fix: paginate getAccounts beyond the first 50 Cloudflare accounts

### DIFF
--- a/.changeset/e41f2cb0.md
+++ b/.changeset/e41f2cb0.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Paginate Cloudflare account listing beyond the first 50 accounts

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -132,7 +132,12 @@ describe("getAccounts", () => {
 
   beforeAll(() => {
     server = startTestServer({
-      "/accounts": successResponse(ACCOUNTS_FIXTURE),
+      "/accounts": successResponse(ACCOUNTS_FIXTURE, {
+        count: 1,
+        page: 1,
+        per_page: 50,
+        total_count: 1,
+      }),
     });
     process.env.CF_API_BASE_URL = server.baseUrl;
   });
@@ -148,6 +153,106 @@ describe("getAccounts", () => {
     if (result.isOk()) {
       expect(result.value[0]?.id).toBe("acct-1");
       expect(result.value[0]?.name).toBe("Acme Corp");
+    }
+  });
+});
+
+describe("getAccounts — pagination", () => {
+  let server: TestServer;
+  const page1Accounts = Array.from({ length: 50 }, (_, index) => ({
+    id: `acct-${index}`,
+    name: `Account ${index}`,
+  }));
+  const page2Accounts = [{ id: "acct-50", name: "Account 50" }];
+
+  beforeAll(() => {
+    server = startTestServer({
+      "/accounts": (req) => {
+        const url = new URL(req.url);
+        const page = Number(url.searchParams.get("page") ?? "1");
+        const perPage = Number(url.searchParams.get("per_page") ?? "50");
+
+        if (page === 1) {
+          return successResponse(page1Accounts, {
+            count: 50,
+            page: 1,
+            per_page: perPage,
+            total_count: 51,
+          });
+        }
+        if (page === 2) {
+          return successResponse(page2Accounts, {
+            count: 1,
+            page: 2,
+            per_page: perPage,
+            total_count: 51,
+          });
+        }
+        return successResponse([], {
+          count: 0,
+          page,
+          per_page: perPage,
+          total_count: 51,
+        });
+      },
+    });
+    process.env.CF_API_BASE_URL = server.baseUrl;
+  });
+
+  afterAll(() => {
+    server.stop();
+    delete process.env.CF_API_BASE_URL;
+  });
+
+  test("aggregates accounts across multiple pages", async () => {
+    const result = await getAccounts("my-token");
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(51);
+      expect(result.value[0]?.id).toBe("acct-0");
+      expect(result.value[49]?.id).toBe("acct-49");
+      expect(result.value[50]?.id).toBe("acct-50");
+    }
+  });
+});
+
+describe("getAccounts — pagination error", () => {
+  let server: TestServer;
+  const page1Accounts = Array.from({ length: 50 }, (_, index) => ({
+    id: `acct-${index}`,
+    name: `Account ${index}`,
+  }));
+
+  beforeAll(() => {
+    server = startTestServer({
+      "/accounts": (req) => {
+        const url = new URL(req.url);
+        const page = Number(url.searchParams.get("page") ?? "1");
+
+        if (page === 1) {
+          return successResponse(page1Accounts, {
+            count: 50,
+            page: 1,
+            per_page: 50,
+            total_count: 51,
+          });
+        }
+        return errorResponse(["Rate limited"]);
+      },
+    });
+    process.env.CF_API_BASE_URL = server.baseUrl;
+  });
+
+  afterAll(() => {
+    server.stop();
+    delete process.env.CF_API_BASE_URL;
+  });
+
+  test("returns Err(CloudflareApiError) when a later page fails", async () => {
+    const result = await getAccounts("my-token");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(CloudflareApiError);
     }
   });
 });

--- a/__tests__/helpers/test-server.ts
+++ b/__tests__/helpers/test-server.ts
@@ -59,8 +59,22 @@ export function startTestServer(routes: Routes): TestServer {
   };
 }
 
-export function successResponse<T>(result: T): RouteHandler {
-  return { body: { errors: [], result, success: true } };
+export interface CfResultInfo {
+  count?: number;
+  page?: number;
+  per_page?: number;
+  total_count?: number;
+}
+
+export function successResponse<T>(
+  result: T,
+  resultInfo?: CfResultInfo
+): RouteHandler {
+  const body: Record<string, unknown> = { errors: [], result, success: true };
+  if (resultInfo) {
+    body.result_info = resultInfo;
+  }
+  return { body };
 }
 
 export function errorResponse(messages: string[], status = 400): RouteHandler {

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,6 +10,23 @@ import type {
 } from "#src/types.ts";
 
 const TRAILING_SLASH_REGEX = /\/+$/u;
+const ACCOUNTS_PER_PAGE = 50;
+
+/** Pagination metadata returned by Cloudflare list endpoints. */
+interface CfResultInfo {
+  count?: number;
+  page?: number;
+  per_page?: number;
+  total_count?: number;
+}
+
+/** Cloudflare list response envelope including pagination metadata. */
+interface CfListResponse<T> {
+  success: boolean;
+  result: T[];
+  errors: { message: string }[];
+  result_info?: CfResultInfo;
+}
 
 /**
  * Resolve the Cloudflare API base URL.
@@ -73,6 +90,95 @@ function cfGet<T>(
 }
 
 /**
+ * Fetch one page from a Cloudflare paginated list endpoint.
+ *
+ * @throws {CloudflareApiError} When the API returns `success: false`.
+ */
+async function fetchCfListPage<T>(
+  basePath: string,
+  apiToken: string,
+  page: number,
+  perPage: number
+): Promise<CfListResponse<T>> {
+  const path = `${basePath}?per_page=${perPage}&page=${page}`;
+  const res = await fetch(`${cfApiBase()}${path}`, {
+    headers: authHeaders(apiToken),
+  });
+  const json = (await res.json()) as CfListResponse<T>;
+  if (!json.success) {
+    throw new CloudflareApiError({
+      messages: json.errors.map((e) => e.message),
+      path,
+    });
+  }
+  return json;
+}
+
+/**
+ * Determine whether pagination should stop after the current page.
+ */
+function isLastCfListPage<T>(
+  pageItems: T[],
+  info: CfResultInfo | undefined,
+  accumulatedCount: number,
+  perPage: number
+): boolean {
+  if (pageItems.length === 0) {
+    return true;
+  }
+  if (info?.total_count !== undefined && accumulatedCount >= info.total_count) {
+    return true;
+  }
+  const pageSize = info?.per_page ?? perPage;
+  return pageItems.length < pageSize;
+}
+
+/**
+ * Recursively fetch remaining pages from a Cloudflare paginated list endpoint.
+ */
+async function fetchCfListPages<T>(
+  basePath: string,
+  apiToken: string,
+  page: number,
+  perPage: number,
+  accumulated: T[]
+): Promise<T[]> {
+  const json = await fetchCfListPage<T>(basePath, apiToken, page, perPage);
+  const pageItems = json.result;
+  const next = [...accumulated, ...pageItems];
+
+  if (isLastCfListPage(pageItems, json.result_info, next.length, perPage)) {
+    return next;
+  }
+
+  return fetchCfListPages(basePath, apiToken, page + 1, perPage, next);
+}
+
+/**
+ * Internal helper for paginated GET list endpoints.
+ * Fetches every page and concatenates `result` arrays.
+ *
+ * @template T - Item type within the paginated `result` array.
+ * @param basePath - API path without query string (e.g. `"/accounts"`).
+ * @param apiToken - Scoped Cloudflare API token.
+ * @param perPage - Page size passed as `per_page` (default 50).
+ * @returns A `Result<T[], CloudflareApiError | UnhandledException>`.
+ */
+function cfGetPaginatedList<T>(
+  basePath: string,
+  apiToken: string,
+  perPage = ACCOUNTS_PER_PAGE
+): Promise<Result<T[], CloudflareApiError | UnhandledException>> {
+  return Result.tryPromise({
+    catch: (e) =>
+      e instanceof CloudflareApiError
+        ? e
+        : new UnhandledException({ cause: e }),
+    try: () => fetchCfListPages<T>(basePath, apiToken, 1, perPage, []),
+  });
+}
+
+/**
  * Fetch the authenticated user's profile.
  *
  * @param apiToken - Scoped Cloudflare API token.
@@ -85,7 +191,8 @@ export function getUser(
 }
 
 /**
- * Fetch all accounts the authenticated user has access to (up to 50).
+ * Fetch all accounts the authenticated user has access to.
+ * Paginates through the Cloudflare API until every page is retrieved.
  *
  * @param apiToken - Scoped Cloudflare API token.
  * @returns `Result<Account[], CloudflareApiError | UnhandledException>`
@@ -93,7 +200,7 @@ export function getUser(
 export function getAccounts(
   apiToken: string
 ): Promise<Result<Account[], CloudflareApiError | UnhandledException>> {
-  return cfGet<Account[]>("/accounts?per_page=50", apiToken);
+  return cfGetPaginatedList<Account>("/accounts", apiToken);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Paginate \getAccounts\ through Cloudflare API pages using \esult_info\ until all accounts are retrieved
- Add multi-page and pagination-error unit tests via the shared \	est-server\ helper
- Closes #111

## Test plan
- [x] \un run typecheck\
- [x] \un run check\
- [x] \un test\ (68 pass)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pagination in getAccounts to fetch all Cloudflare accounts, not just the first 50. Users with 51+ accounts can now see and select all accounts.

- **Bug Fixes**
  - Iterate through `/accounts` pages using `result_info` until all accounts are collected.
  - Add unit tests for multi-page aggregation and pagination error cases (extended test server to emit `result_info`).

<sup>Written for commit 86c116df7fe3b588c52a76ae1b0ad034460cb422. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Paginate `getAccounts` to fetch all Cloudflare accounts beyond the first 50
> Previously, `getAccounts` issued a single request capped at 50 results. It now fetches all pages using new helpers in [src/api.ts](https://github.com/mynameistito/create-cf-token/pull/124/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700): `fetchCfListPages` recursively accumulates results, stopping when `result_info.total_count` is satisfied or a short/empty page is detected. If any page request fails, the full call returns an `Err` with a `CloudflareApiError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86c116d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->