### PR TITLE
feat: Select All shortcuts and bulk access-level for full-access tokens

### DIFF
--- a/.changeset/6ce3cb51.md
+++ b/.changeset/6ce3cb51.md
@@ -2,4 +2,4 @@
 "create-cf-token": minor
 ---
 
-Add a one-click full-access preset (all accounts, all scopes, read + write), Select All shortcuts in multiselect prompts, and a bulk access-level prompt when every scope is selected manually (fixes #127)
+Add a one-click full-access preset (all accounts, all scopes, read + write), Select All shortcuts in multiselect prompts, a bulk access-level prompt when every scope is selected manually, and exclude API token management permissions that sub-tokens cannot grant (fixes #127)

--- a/.changeset/6ce3cb51.md
+++ b/.changeset/6ce3cb51.md
@@ -2,4 +2,4 @@
 "create-cf-token": minor
 ---
 
-Add Select All shortcuts and bulk access-level prompt for full-access tokens (fixes #127)
+Add a one-click full-access preset (all accounts, all scopes, read + write), Select All shortcuts in multiselect prompts, and a bulk access-level prompt when every scope is selected manually (fixes #127)

--- a/.changeset/6ce3cb51.md
+++ b/.changeset/6ce3cb51.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": minor
+---
+
+Add Select All shortcuts and bulk access-level prompt for full-access tokens (fixes #127)

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -401,6 +401,35 @@ describe("createToken — restricted perm in raw text fallback", () => {
   });
 });
 
+describe("createToken — sub-token cannot manage other tokens", () => {
+  let server: TestServer;
+
+  beforeAll(() => {
+    server = startTestServer({
+      "/user/tokens": errorResponse([
+        "sub-token is not allowed to have permissions to manage other tokens",
+      ]),
+    });
+    process.env.CF_API_BASE_URL = server.baseUrl;
+  });
+
+  afterAll(() => {
+    server.stop();
+    delete process.env.CF_API_BASE_URL;
+  });
+
+  test("returns Err(RestrictedPermissionError) mapped to API Tokens service", async () => {
+    const result = await createToken("my-token", "Test", []);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(RestrictedPermissionError);
+      if (result.error instanceof RestrictedPermissionError) {
+        expect(result.error.permissionName).toBe("API Tokens");
+      }
+    }
+  });
+});
+
 describe("deleteToken — success", () => {
   let server: TestServer;
 

--- a/__tests__/build-policies.test.ts
+++ b/__tests__/build-policies.test.ts
@@ -165,4 +165,31 @@ describe("buildPolicies", () => {
     const [policy] = buildPolicies(perms, USER_ID, ACCOUNTS, excluded);
     expect(policy?.permission_groups).toEqual([{ id: "p1" }]);
   });
+
+  test("excludes every permission for a service when the base name is excluded", () => {
+    const perms = [
+      {
+        description: "",
+        id: "p1",
+        name: "API Tokens Read",
+        scopes: ["com.cloudflare.api.user"],
+      },
+      {
+        description: "",
+        id: "p2",
+        name: "API Tokens Write",
+        scopes: ["com.cloudflare.api.user"],
+      },
+      {
+        description: "",
+        id: "p3",
+        name: "DNS Read",
+        scopes: ["com.cloudflare.api.account.zone"],
+      },
+    ];
+    const excluded = new Set(["API Tokens"]);
+    const policies = buildPolicies(perms, USER_ID, ACCOUNTS, excluded);
+    expect(policies).toHaveLength(1);
+    expect(policies[0]?.permission_groups).toEqual([{ id: "p3" }]);
+  });
 });

--- a/__tests__/permissions.test.ts
+++ b/__tests__/permissions.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { extractFailedPerm, groupByService } from "#src/permissions.ts";
+import {
+  extractFailedPerm,
+  groupByService,
+  isPermissionExcluded,
+} from "#src/permissions.ts";
 
 describe("extractFailedPerm", () => {
   test("extracts restricted permission names from supported Cloudflare error formats", () => {
@@ -32,6 +36,11 @@ describe("extractFailedPerm", () => {
         error: 'validation failed for permission_group "Account Settings Read"',
         expected: "Account Settings Read",
       },
+      {
+        error:
+          '{"success":false,"errors":[{"code":1001,"message":"sub-token is not allowed to have permissions to manage other tokens"}]}',
+        expected: "API Tokens",
+      },
     ] as const;
 
     for (const { error, expected } of cases) {
@@ -53,6 +62,22 @@ describe("extractFailedPerm", () => {
     for (const { error, expected } of cases) {
       expect(extractFailedPerm(error)).toBe(expected);
     }
+  });
+});
+
+describe("isPermissionExcluded", () => {
+  test("matches exact permission names", () => {
+    const excluded = new Set(["DNS Write"]);
+    expect(isPermissionExcluded("DNS Write", excluded)).toBe(true);
+    expect(isPermissionExcluded("DNS Read", excluded)).toBe(false);
+  });
+
+  test("matches service base names across read, write, and edit permissions", () => {
+    const excluded = new Set(["API Tokens"]);
+    expect(isPermissionExcluded("API Tokens Read", excluded)).toBe(true);
+    expect(isPermissionExcluded("API Tokens Write", excluded)).toBe(true);
+    expect(isPermissionExcluded("API Tokens Edit", excluded)).toBe(true);
+    expect(isPermissionExcluded("DNS Read", excluded)).toBe(false);
   });
 });
 

--- a/__tests__/prompts-scope.test.ts
+++ b/__tests__/prompts-scope.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildPermissionsForSelection, GO_BACK } from "#src/prompts.ts";
+import {
+  buildPermissionsForSelection,
+  GO_BACK,
+  isAllScopesSelected,
+} from "#src/prompts.ts";
 import type { PermissionGroup, ServiceGroup } from "#src/types.ts";
 
 const ZONE_SCOPE = "com.cloudflare.api.account.zone";
@@ -55,6 +59,30 @@ function readOnlyServiceGroup(): {
     },
   };
 }
+
+describe("isAllScopesSelected", () => {
+  test("returns true when every scope is selected", () => {
+    const dns = dnsServiceGroup();
+    const analytics = readOnlyServiceGroup();
+
+    expect(
+      isAllScopesSelected(
+        [dns.service, analytics.service],
+        [dns.service.name, analytics.service.name]
+      )
+    ).toBe(true);
+  });
+
+  test("returns false for partial or empty selections", () => {
+    const dns = dnsServiceGroup();
+    const analytics = readOnlyServiceGroup();
+    const scopes = [dns.service, analytics.service];
+
+    expect(isAllScopesSelected(scopes, [dns.service.name])).toBe(false);
+    expect(isAllScopesSelected(scopes, [])).toBe(false);
+    expect(isAllScopesSelected([], [])).toBe(false);
+  });
+});
 
 describe("buildPermissionsForSelection", () => {
   test("read-only excludes edit-class otherPerms", async () => {
@@ -128,5 +156,41 @@ describe("buildPermissionsForSelection", () => {
     );
 
     expect(result).toEqual(reselected);
+  });
+
+  test("all scopes selected uses one bulk access level for read/write services", async () => {
+    const dns = dnsServiceGroup();
+    const analytics = readOnlyServiceGroup();
+    let accessLevelPrompts = 0;
+    const result = await buildPermissionsForSelection(
+      [dns.service, analytics.service],
+      [dns.service.name, analytics.service.name],
+      () => Promise.resolve([]),
+      () => {
+        accessLevelPrompts += 1;
+        return Promise.resolve("write");
+      }
+    );
+
+    expect(accessLevelPrompts).toBe(1);
+    expect(result).toEqual([
+      dns.readPerm,
+      dns.writePerm,
+      dns.editPerm,
+      analytics.readPerm,
+    ]);
+  });
+
+  test("all scopes selected with read-only bulk level excludes write perms", async () => {
+    const dns = dnsServiceGroup();
+    const analytics = readOnlyServiceGroup();
+    const result = await buildPermissionsForSelection(
+      [dns.service, analytics.service],
+      [dns.service.name, analytics.service.name],
+      () => Promise.resolve([]),
+      () => Promise.resolve("read")
+    );
+
+    expect(result).toEqual([dns.readPerm, analytics.readPerm]);
   });
 });

--- a/__tests__/prompts-scope.test.ts
+++ b/__tests__/prompts-scope.test.ts
@@ -205,4 +205,28 @@ describe("resolveFullAccessPermissions", () => {
       resolveFullAccessPermissions([dns.service, analytics.service])
     ).toEqual([dns.readPerm, dns.writePerm, dns.editPerm, analytics.readPerm]);
   });
+
+  test("omits API token management permissions", () => {
+    const dns = dnsServiceGroup();
+    const tokenRead = perm("tokens-read", "API Tokens Read", [
+      "com.cloudflare.api.user",
+    ]);
+    const tokenWrite = perm("tokens-write", "API Tokens Write", [
+      "com.cloudflare.api.user",
+    ]);
+    const tokenService: ServiceGroup = {
+      name: "API Tokens",
+      otherPerms: [],
+      perms: [tokenRead, tokenWrite],
+      readPerm: tokenRead,
+      scopes: ["com.cloudflare.api.user"],
+      writePerm: tokenWrite,
+    };
+
+    expect(resolveFullAccessPermissions([dns.service, tokenService])).toEqual([
+      dns.readPerm,
+      dns.writePerm,
+      dns.editPerm,
+    ]);
+  });
 });

--- a/__tests__/prompts-scope.test.ts
+++ b/__tests__/prompts-scope.test.ts
@@ -4,6 +4,7 @@ import {
   buildPermissionsForSelection,
   GO_BACK,
   isAllScopesSelected,
+  resolveFullAccessPermissions,
 } from "#src/prompts.ts";
 import type { PermissionGroup, ServiceGroup } from "#src/types.ts";
 
@@ -192,5 +193,16 @@ describe("buildPermissionsForSelection", () => {
     );
 
     expect(result).toEqual([dns.readPerm, analytics.readPerm]);
+  });
+});
+
+describe("resolveFullAccessPermissions", () => {
+  test("grants read, write, and edit for every read/write service", () => {
+    const dns = dnsServiceGroup();
+    const analytics = readOnlyServiceGroup();
+
+    expect(
+      resolveFullAccessPermissions([dns.service, analytics.service])
+    ).toEqual([dns.readPerm, dns.writePerm, dns.editPerm, analytics.readPerm]);
   });
 });

--- a/__tests__/prompts-scope.test.ts
+++ b/__tests__/prompts-scope.test.ts
@@ -5,6 +5,7 @@ import {
   GO_BACK,
   isAllScopesSelected,
   resolveFullAccessPermissions,
+  shouldToggleSelectAll,
 } from "#src/prompts.ts";
 import type { PermissionGroup, ServiceGroup } from "#src/types.ts";
 
@@ -60,6 +61,23 @@ function readOnlyServiceGroup(): {
     },
   };
 }
+
+describe("shouldToggleSelectAll", () => {
+  test("Ctrl+A always toggles", () => {
+    expect(shouldToggleSelectAll({ ctrl: true, name: "a" }, false)).toBe(true);
+    expect(shouldToggleSelectAll({ ctrl: true, name: "a" }, true)).toBe(true);
+  });
+
+  test("bare a toggles only after list navigation", () => {
+    expect(shouldToggleSelectAll({ name: "a" }, true)).toBe(true);
+    expect(shouldToggleSelectAll({ name: "a" }, false)).toBe(false);
+  });
+
+  test("ignores unrelated keys", () => {
+    expect(shouldToggleSelectAll({ name: "b" }, true)).toBe(false);
+    expect(shouldToggleSelectAll(undefined, true)).toBe(false);
+  });
+});
 
 describe("isAllScopesSelected", () => {
   test("returns true when every scope is selected", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
 } from "#src/api.ts";
 import colour from "#src/colour.ts";
 import type { CloudflareApiError } from "#src/errors.ts";
-import { groupByService } from "#src/permissions.ts";
+import { groupByService, isPermissionExcluded } from "#src/permissions.ts";
 import {
   askCredentials,
   askDeleteCreatedTokens,
@@ -105,7 +105,9 @@ export function buildPolicies(
   const USER_SCOPE = "com.cloudflare.api.user";
   const ZONE_SCOPE = "com.cloudflare.api.account.zone";
 
-  const filteredPerms = perms.filter((p) => !excluded.has(p.name));
+  const filteredPerms = perms.filter(
+    (p) => !isPermissionExcluded(p.name, excluded)
+  );
   const userPerms = filteredPerms.filter((p) => p.scopes.includes(USER_SCOPE));
   const zonePerms = filteredPerms.filter(
     (p) => !p.scopes.includes(USER_SCOPE) && p.scopes.includes(ZONE_SCOPE)

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   askDeleteCreatedTokens,
   askPostCreateAction,
   askTokenName,
+  askTokenPreset,
   buildAuthTemplateUrl,
   CF_API_TOKENS_URL,
   CF_AUTH_TEMPLATE_URL,
@@ -32,6 +33,7 @@ import {
   hyperlinkUrl,
   logMessage,
   printNote,
+  resolveFullAccessPermissions,
   selectAccounts,
   selectScopes,
   showCreatedToken,
@@ -313,6 +315,24 @@ async function tokenCreateFlow(
       chosenPerms as PermissionGroup[],
       userId,
       selectedAccounts,
+      s
+    );
+  }
+
+  const preset = await askTokenPreset();
+
+  if (preset === "full-access") {
+    const tokenName = await askTokenName("Full Access Token");
+    if (tokenName === GO_BACK) {
+      return tokenCreateFlow(accounts, scopes, userId, apiToken, s);
+    }
+
+    return attemptCreateToken(
+      apiToken,
+      tokenName as string,
+      resolveFullAccessPermissions(scopes),
+      userId,
+      accounts,
       s
     );
   }

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,5 +1,8 @@
 import type { PermissionGroup, ServiceGroup } from "#src/types.ts";
 
+/** Service group for API token management — sub-tokens cannot grant these to child tokens. */
+export const TOKEN_MANAGEMENT_SERVICE = "API Tokens";
+
 /** Action suffixes used to classify permission groups as read, write, or edit. */
 const PERMISSION_ACTION_SUFFIXES = [
   { action: "read", suffix: " Read" },
@@ -173,6 +176,14 @@ function extractFailedPermFromSource(source: string): string | null {
   const normalizedSource = normalizePermissionSource(source);
   const lowercaseSource = normalizedSource.toLowerCase();
 
+  if (
+    lowercaseSource.includes(
+      "sub-token is not allowed to have permissions to manage other tokens"
+    )
+  ) {
+    return TOKEN_MANAGEMENT_SERVICE;
+  }
+
   for (const { allowUnquotedValue, marker } of PERMISSION_GROUP_MARKERS) {
     const markerIndex = lowercaseSource.indexOf(marker);
     if (markerIndex === -1) {
@@ -189,6 +200,24 @@ function extractFailedPermFromSource(source: string): string | null {
   }
 
   return null;
+}
+
+/**
+ * Whether a permission should be omitted from token policies.
+ * Matches exact permission names and service base names (e.g. `API Tokens` excludes `API Tokens Write`).
+ *
+ * @param permissionName - Full permission group name from the Cloudflare API.
+ * @param excluded - Permission or service names to omit.
+ */
+export function isPermissionExcluded(
+  permissionName: string,
+  excluded: Set<string>
+): boolean {
+  if (excluded.has(permissionName)) {
+    return true;
+  }
+
+  return excluded.has(stripPermissionActionSuffix(permissionName));
 }
 
 export function extractFailedPerm(

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -192,6 +192,9 @@ type Backable<T> = T | typeof GO_BACK;
 /** Actions available after a token template URL is generated. */
 type PostCreateAction = "again" | "done" | "revoke-again" | "revoke-done";
 
+/** Upfront token permission preset chosen before account/scope pickers. */
+export type TokenPreset = "custom" | "full-access";
+
 /** A single selectable option used by search and select prompts. */
 interface SearchOption {
   /** When `true`, the option is visible but cannot be selected. */
@@ -1288,6 +1291,28 @@ function appendServicePermissions(
 }
 
 /**
+ * Resolve every available scope to read + write permission groups.
+ *
+ * @param scopes - All available service groups.
+ * @returns Permission groups for a full-access token.
+ */
+export function resolveFullAccessPermissions(
+  scopes: ServiceGroup[]
+): PermissionGroup[] {
+  const chosen: PermissionGroup[] = [];
+
+  for (const service of scopes) {
+    appendServicePermissions(
+      chosen,
+      service,
+      service.readPerm && service.writePerm ? "write" : undefined
+    );
+  }
+
+  return chosen;
+}
+
+/**
  * For each selected scope, resolve its concrete permission groups.
  *
  * When a service has both read and write permissions, a sub-prompt asks the
@@ -1386,6 +1411,27 @@ export function buildPermissionsForSelection(
   }
 
   return collect(0);
+}
+
+/**
+ * Ask whether to create a full-access token or choose accounts and scopes manually.
+ *
+ * @returns `"full-access"` for all accounts with every scope at read + write, or `"custom"`.
+ */
+export async function askTokenPreset(): Promise<TokenPreset> {
+  exitIfNonInteractive();
+  return check(
+    await select({
+      message: "Token permissions",
+      options: [
+        {
+          label: "All accounts — full read/write access",
+          value: "full-access",
+        },
+        { label: "Custom — choose accounts and scopes", value: "custom" },
+      ],
+    })
+  ) as TokenPreset;
 }
 
 /**

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -531,22 +531,11 @@ export function shouldToggleSelectAll(
 }
 
 /**
- * Clear the search field after a bare `a` select-all shortcut.
- * Readline appends the key before custom handlers run.
- */
-function clearSearchInput(prompt: AutocompletePrompt<SearchOption>): void {
-  type ClearablePrompt = AutocompletePrompt<SearchOption> & {
-    _clearUserInput: () => void;
-  };
-  (prompt as ClearablePrompt)._clearUserInput();
-}
-
-/**
  * Toggle between selecting all enabled options and deselecting all.
  *
  * @param prompt - The active search multiselect prompt.
  */
-function toggleSelectAll(prompt: AutocompletePrompt<SearchOption>): void {
+function toggleSelectAll(prompt: SearchMultiselectPrompt): void {
   const enabled = prompt.options.filter((option) => !option.disabled);
   const allSelected =
     enabled.length > 0 &&
@@ -1069,6 +1058,16 @@ export async function askCredentials(): Promise<{ apiKey: string }> {
 }
 
 /**
+ * Search multiselect with a public helper to reset the query field.
+ * Uses subclass access to `@clack/core` protected APIs instead of external casts.
+ */
+class SearchMultiselectPrompt extends AutocompletePrompt<SearchOption> {
+  clearSearchField(): void {
+    this._clearUserInput();
+  }
+}
+
+/**
  * Show a fuzzy-searchable multi-select prompt with optional back-navigation.
  *
  * When `allowBack` is `true`, pressing Backspace with an empty search input
@@ -1096,7 +1095,7 @@ async function searchMultiselect(
   allowBack: boolean
 ): Promise<Backable<string[]>> {
   exitIfNonInteractive();
-  const prompt = new AutocompletePrompt<SearchOption>({
+  const prompt = new SearchMultiselectPrompt({
     filter: matchesSearch,
     multiple: true,
     options,
@@ -1148,7 +1147,7 @@ async function searchMultiselect(
   prompt.on("key", (char, key) => {
     if (shouldToggleSelectAll(key, navigatingList)) {
       if (key?.name === "a" && !key?.ctrl) {
-        clearSearchInput(prompt);
+        prompt.clearSearchField();
       }
       toggleSelectAll(prompt);
       navigatingList = false;

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1468,13 +1468,14 @@ export async function askTokenPreset(): Promise<TokenPreset> {
   exitIfNonInteractive();
   return check(
     await select({
+      initialValue: "custom",
       message: "Token permissions",
       options: [
+        { label: "Custom — choose accounts and scopes", value: "custom" },
         {
           label: "All accounts — full read/write access",
           value: "full-access",
         },
-        { label: "Custom — choose accounts and scopes", value: "custom" },
       ],
     })
   ) as TokenPreset;

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -45,6 +45,7 @@ import {
 } from "@clack/prompts";
 
 import colour from "#src/colour.ts";
+import { TOKEN_MANAGEMENT_SERVICE } from "#src/permissions.ts";
 import type {
   Account,
   CreatedToken,
@@ -1302,6 +1303,10 @@ export function resolveFullAccessPermissions(
   const chosen: PermissionGroup[] = [];
 
   for (const service of scopes) {
+    if (service.name === TOKEN_MANAGEMENT_SERVICE) {
+      continue;
+    }
+
     appendServicePermissions(
       chosen,
       service,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -208,6 +208,7 @@ interface SearchOption {
 
 /** Key event metadata from `@clack/core`. */
 interface KeypressInfo {
+  ctrl?: boolean;
   name?: string;
   sequence?: string;
 }
@@ -508,6 +509,39 @@ function isBackspaceKey(
 }
 
 /**
+ * Whether a keypress should toggle select-all in a search multiselect.
+ * Ctrl+A always toggles; bare `a` toggles only while navigating the option list.
+ */
+function isSelectAllKey(
+  prompt: SearchPromptState,
+  key: KeypressInfo | undefined
+): boolean {
+  return (
+    (key?.ctrl === true && key?.name === "a") ||
+    (key?.name === "a" && prompt.isNavigating)
+  );
+}
+
+/**
+ * Toggle between selecting all enabled options and deselecting all.
+ *
+ * @param prompt - The active search multiselect prompt.
+ */
+function toggleSelectAll(prompt: AutocompletePrompt<SearchOption>): void {
+  const enabled = prompt.options.filter((option) => !option.disabled);
+  const allSelected =
+    enabled.length > 0 &&
+    enabled.every((option) => prompt.selectedValues.includes(option.value));
+
+  if (allSelected) {
+    prompt.deselectAll();
+    return;
+  }
+
+  prompt.selectedValues = enabled.map((option) => option.value);
+}
+
+/**
  * Render a single option row in the multi-select search prompt.
  *
  * @param option - The option to render.
@@ -631,6 +665,7 @@ function getSearchFooterLines(
       `${styleText("dim", "↑/↓")} navigate`,
       `${styleText("dim", selectHint)} select`,
       `${styleText("dim", "←:")} deselect`,
+      `${styleText("dim", "Ctrl+A:")} all`,
       `${styleText("dim", "Enter:")} confirm`,
       `${styleText("dim", "Type:")} search`,
     ],
@@ -1081,6 +1116,11 @@ async function searchMultiselect(
   });
 
   prompt.on("key", (char, key) => {
+    if (isSelectAllKey(prompt, key)) {
+      toggleSelectAll(prompt);
+      return;
+    }
+
     if (
       !allowBack ||
       prompt.userInput.length > 0 ||
@@ -1187,11 +1227,75 @@ function buildScopeOptions(scopes: ServiceGroup[]): SearchOption[] {
 type AccessLevel = "read" | "write";
 
 /**
+ * Returns `true` when every available service scope is selected.
+ *
+ * @param scopes - All available service groups.
+ * @param selected - Names of scopes the user checked in the multi-select.
+ */
+export function isAllScopesSelected(
+  scopes: ServiceGroup[],
+  selected: string[]
+): boolean {
+  if (scopes.length === 0 || selected.length !== scopes.length) {
+    return false;
+  }
+
+  const scopeNames = new Set(scopes.map((scope) => scope.name));
+  return selected.every((name) => scopeNames.has(name));
+}
+
+/**
+ * Whether a single bulk access-level prompt should replace per-service prompts.
+ */
+function shouldUseBulkAccessLevel(
+  scopes: ServiceGroup[],
+  selected: string[]
+): boolean {
+  return (
+    isAllScopesSelected(scopes, selected) &&
+    scopes.some((scope) => scope.readPerm && scope.writePerm)
+  );
+}
+
+/**
+ * Append a service's permission groups to the chosen list.
+ *
+ * @param chosen - Accumulator for resolved permission groups.
+ * @param service - The service whose permissions should be added.
+ * @param level - Access level for read/write services; omitted for read-only services.
+ */
+function appendServicePermissions(
+  chosen: PermissionGroup[],
+  service: ServiceGroup,
+  level?: AccessLevel
+): void {
+  if (!(service.readPerm && service.writePerm)) {
+    chosen.push(...service.otherPerms);
+    if (service.readPerm) {
+      chosen.push(service.readPerm);
+    }
+    if (service.writePerm) {
+      chosen.push(service.writePerm);
+    }
+    return;
+  }
+
+  chosen.push(service.readPerm);
+  if (level === "write") {
+    chosen.push(service.writePerm);
+    chosen.push(...service.otherPerms);
+  }
+}
+
+/**
  * For each selected scope, resolve its concrete permission groups.
  *
  * When a service has both read and write permissions, a sub-prompt asks the
  * user to choose the access level. Edit-class permissions in `otherPerms` are
  * included only when the user selects read + write.
+ *
+ * When every scope is selected, a single bulk access-level prompt is shown
+ * instead of one prompt per service.
  *
  * @param scopes - All available service groups.
  * @param selected - Names of scopes the user checked in the multi-select.
@@ -1207,7 +1311,49 @@ export function buildPermissionsForSelection(
 ): Promise<Backable<PermissionGroup[]>> {
   const chosen: PermissionGroup[] = [];
 
+  async function resolveBulkAccessLevel(): Promise<Backable<AccessLevel>> {
+    const templateService =
+      scopes.find((scope) => scope.readPerm && scope.writePerm) ?? scopes[0];
+
+    if (!templateService) {
+      return "read";
+    }
+
+    if (selectAccessLevel) {
+      return await selectAccessLevel(templateService);
+    }
+
+    const level = await selectWithBack("All scopes — access level", [
+      { label: "Read only", value: "read" },
+      { label: "Read + Write", value: "write" },
+    ]);
+
+    return level === GO_BACK ? GO_BACK : (level as AccessLevel);
+  }
+
   async function collect(index: number): Promise<Backable<PermissionGroup[]>> {
+    if (index === 0 && shouldUseBulkAccessLevel(scopes, selected)) {
+      const level = await resolveBulkAccessLevel();
+
+      if (level === GO_BACK) {
+        return reselectScopes();
+      }
+
+      for (const scopeName of selected) {
+        const service = scopes.find((scope) => scope.name === scopeName);
+
+        if (service) {
+          appendServicePermissions(
+            chosen,
+            service,
+            service.readPerm && service.writePerm ? level : undefined
+          );
+        }
+      }
+
+      return chosen;
+    }
+
     const scopeName = selected[index];
     if (scopeName === undefined) {
       return chosen;
@@ -1220,33 +1366,22 @@ export function buildPermissionsForSelection(
     }
 
     if (!(service.readPerm && service.writePerm)) {
-      chosen.push(...service.otherPerms);
-      if (service.readPerm) {
-        chosen.push(service.readPerm);
-      }
-      if (service.writePerm) {
-        chosen.push(service.writePerm);
-      }
+      appendServicePermissions(chosen, service);
       return collect(index + 1);
     }
 
     const level = selectAccessLevel
       ? await selectAccessLevel(service)
-      : await selectWithBack(`${service.name} — access level`, [
+      : ((await selectWithBack(`${service.name} — access level`, [
           { label: "Read only", value: "read" },
           { label: "Read + Write", value: "write" },
-        ]);
+        ])) as Backable<AccessLevel>);
 
     if (level === GO_BACK) {
       return reselectScopes();
     }
 
-    chosen.push(service.readPerm);
-    if (level === "write") {
-      chosen.push(service.writePerm);
-      chosen.push(...service.otherPerms);
-    }
-
+    appendServicePermissions(chosen, service, level);
     return collect(index + 1);
   }
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -514,16 +514,31 @@ function isBackspaceKey(
 
 /**
  * Whether a keypress should toggle select-all in a search multiselect.
- * Ctrl+A always toggles; bare `a` toggles only while navigating the option list.
+ * Ctrl+A always toggles; bare `a` toggles only after the user navigated the option list.
+ *
+ * Bare `a` cannot use `prompt.isNavigating` — AutocompletePrompt clears that flag
+ * in its own key handler before custom listeners run.
  */
-function isSelectAllKey(
-  prompt: SearchPromptState,
-  key: KeypressInfo | undefined
+export function shouldToggleSelectAll(
+  key: KeypressInfo | undefined,
+  navigatingList: boolean
 ): boolean {
-  return (
-    (key?.ctrl === true && key?.name === "a") ||
-    (key?.name === "a" && prompt.isNavigating)
-  );
+  if (key?.ctrl === true && key?.name === "a") {
+    return true;
+  }
+
+  return key?.name === "a" && !key?.ctrl && navigatingList;
+}
+
+/**
+ * Clear the search field after a bare `a` select-all shortcut.
+ * Readline appends the key before custom handlers run.
+ */
+function clearSearchInput(prompt: AutocompletePrompt<SearchOption>): void {
+  type ClearablePrompt = AutocompletePrompt<SearchOption> & {
+    _clearUserInput: () => void;
+  };
+  (prompt as ClearablePrompt)._clearUserInput();
 }
 
 /**
@@ -669,7 +684,7 @@ function getSearchFooterLines(
       `${styleText("dim", "↑/↓")} navigate`,
       `${styleText("dim", selectHint)} select`,
       `${styleText("dim", "←:")} deselect`,
-      `${styleText("dim", "Ctrl+A:")} all`,
+      `${styleText("dim", "Ctrl+A/a:")} all`,
       `${styleText("dim", "Enter:")} confirm`,
       `${styleText("dim", "Type:")} search`,
     ],
@@ -1095,7 +1110,18 @@ async function searchMultiselect(
     },
   });
 
+  let navigatingList = false;
+
   prompt.on("cursor", (action?: CursorAction) => {
+    if (
+      action === "up" ||
+      action === "down" ||
+      action === "right" ||
+      action === "left"
+    ) {
+      navigatingList = true;
+    }
+
     const { focusedValue } = prompt;
 
     if (!action || focusedValue === undefined) {
@@ -1120,9 +1146,24 @@ async function searchMultiselect(
   });
 
   prompt.on("key", (char, key) => {
-    if (isSelectAllKey(prompt, key)) {
+    if (shouldToggleSelectAll(key, navigatingList)) {
+      if (key?.name === "a" && !key?.ctrl) {
+        clearSearchInput(prompt);
+      }
       toggleSelectAll(prompt);
+      navigatingList = false;
       return;
+    }
+
+    if (
+      char &&
+      char.length === 1 &&
+      !key?.ctrl &&
+      key?.name !== "backspace" &&
+      key?.name !== "return" &&
+      key?.name !== "tab"
+    ) {
+      navigatingList = false;
     }
 
     if (


### PR DESCRIPTION
## Summary

- Adds a **one-click full-access preset** as the first prompt: **All accounts — full read/write access** applies every scope at read + write across all accounts (only token name + create remain)
- Keeps **Custom — choose accounts and scopes** for the existing granular flow
- Ctrl+A select-all shortcuts and bulk access-level prompt remain for the custom path

Closes #127

## Test plan

- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `bun test __tests__/prompts-scope.test.ts`
- [x] Run `bun dev`, pick **All accounts — full read/write access**, confirm no account/scope pickers appear
- [x] Run `bun dev`, pick **Custom**, confirm existing account/scope flow still works


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add full-access token preset and select-all shortcuts to the token creation flow
> - Adds an `askTokenPreset` prompt at the start of token creation; choosing 'full-access' skips account/scope selection and creates a token with read/write permissions across all accounts, defaulting the token name to 'Full Access Token'.
> - Adds `resolveFullAccessPermissions` to generate full read/write permissions for all services, explicitly excluding API token management (`API Tokens` service) since sub-tokens cannot grant those permissions.
> - Adds Ctrl+A and bare 'a' (after navigating the list) select-all shortcuts to the `searchMultiselect` prompt, with a footer hint update.
> - When all scopes are selected, `buildPermissionsForSelection` now prompts once for a bulk access level instead of prompting per-service.
> - Extends `extractFailedPermFromSource` to return `'API Tokens'` when the API rejects a sub-token attempting to manage other tokens, surfacing a typed `RestrictedPermissionError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b3bfdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->