### PR TITLE
fix: remove redundant exit delete prompt after keeping a token

### DIFF
--- a/.changeset/3a1a74f7.md
+++ b/.changeset/3a1a74f7.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Remove redundant exit delete prompt after keeping a token; clarify post-create action labels (fixes #129)

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,6 @@ import type { CloudflareApiError } from "#src/errors.ts";
 import { groupByService, isPermissionExcluded } from "#src/permissions.ts";
 import {
   askCredentials,
-  askDeleteCreatedTokens,
   askPostCreateAction,
   askTokenName,
   askTokenPreset,
@@ -264,20 +263,6 @@ async function deleteTokens(
   );
 }
 
-async function deleteCreatedTokensFlow(
-  sessionTokens: CreatedToken[],
-  apiToken: string,
-  s: ReturnType<typeof createSpinner>
-): Promise<void> {
-  const tokensToDelete = await askDeleteCreatedTokens(sessionTokens);
-
-  if (tokensToDelete.length === 0) {
-    return;
-  }
-
-  await deleteTokens(tokensToDelete, apiToken, s);
-}
-
 export function handleApiError(error: ApiError): never {
   matchError(error, {
     CloudflareApiError: (e) => {
@@ -412,7 +397,6 @@ export async function main(): Promise<void> {
   try {
     let looping = true;
     let previousToken: CreatedToken | undefined;
-    const sessionTokens: CreatedToken[] = [];
 
     while (looping) {
       // oxlint-disable-next-line no-await-in-loop -- interactive multi-token session
@@ -438,15 +422,9 @@ export async function main(): Promise<void> {
         await deleteTokens([createdToken], apiKey, s);
       } else if (action === "revoke-again") {
         previousToken = createdToken;
-      } else {
-        sessionTokens.push(createdToken);
       }
 
       looping = action === "again" || action === "revoke-again";
-    }
-
-    if (sessionTokens.length > 0) {
-      await deleteCreatedTokensFlow(sessionTokens, apiKey, s);
     }
   } catch (error) {
     if (TokenCreationFlowError.is(error) || TokenDeletionFlowError.is(error)) {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -46,12 +46,7 @@ import {
 
 import colour from "#src/colour.ts";
 import { TOKEN_MANAGEMENT_SERVICE } from "#src/permissions.ts";
-import type {
-  Account,
-  CreatedToken,
-  PermissionGroup,
-  ServiceGroup,
-} from "#src/types.ts";
+import type { Account, PermissionGroup, ServiceGroup } from "#src/types.ts";
 
 /** URL to the Cloudflare dashboard API tokens page, shown in prompts and errors. */
 export const CF_API_TOKENS_URL =
@@ -1536,58 +1531,6 @@ export function selectScopes(
  */
 export function askTokenName(defaultName: string): Promise<Backable<string>> {
   return textWithBack("Token name", defaultName);
-}
-
-/**
- * Ask the user what to do after a token has been created.
- *
- * @returns `"done"` or `"again"`.
- */
-export async function askDeleteCreatedTokens(
-  createdTokens: CreatedToken[]
-): Promise<CreatedToken[]> {
-  if (createdTokens.length === 0) {
-    return [];
-  }
-
-  exitIfNonInteractive();
-
-  const shouldDelete = check(
-    await select({
-      message:
-        createdTokens.length === 1
-          ? "Delete the token you created before exiting?"
-          : "Delete any tokens created in this session before exiting?",
-      options: [
-        { label: "No, keep them", value: "no" },
-        { label: "Yes, choose token(s)", value: "yes" },
-      ],
-    })
-  );
-
-  if (shouldDelete !== "yes") {
-    return [];
-  }
-
-  if (createdTokens.length === 1) {
-    return createdTokens;
-  }
-
-  const selectedIds = await searchMultiselect(
-    "Select created tokens to delete",
-    createdTokens.map((token) => ({
-      hint: token.id,
-      label: token.name,
-      value: token.id,
-    })),
-    true
-  );
-
-  if (selectedIds === GO_BACK) {
-    return [];
-  }
-
-  return createdTokens.filter((token) => selectedIds.includes(token.id));
 }
 
 export async function askPostCreateAction(): Promise<PostCreateAction> {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1594,12 +1594,13 @@ export async function askPostCreateAction(): Promise<PostCreateAction> {
   exitIfNonInteractive();
   return check(
     await select({
+      initialValue: "done",
       message: "What should we do with the key you just created?",
       options: [
-        { label: "Keep this key (do nothing)", value: "done" },
-        { label: "Modify this key", value: "revoke-again" },
+        { label: "Keep and finish", value: "done" },
+        { label: "Replace this key", value: "revoke-again" },
         { label: "Delete this key", value: "revoke-done" },
-        { label: "Create another key", value: "again" },
+        { label: "Keep and create another", value: "again" },
       ],
     })
   ) as PostCreateAction;


### PR DESCRIPTION
## Summary

- Removes the redundant exit-time delete prompt that appeared after users already chose **Keep and finish** (fixes #129).
- Clarifies post-create action labels and sets **Keep and finish** as the default (Enter confirms the common path).
- Keeps `askDeleteCreatedTokens` exported for a potential future explicit cleanup flag.

## Test plan

- [ ] Create one token → **Keep and finish** → exits with `Done!` and no second delete prompt
- [ ] Create one token → **Delete this key** → token revoked, exits cleanly
- [ ] Create token A → **Keep and create another** → create token B → **Keep and finish** → no exit delete prompt
- [ ] Create token → **Replace this key** → create token B → prior token deleted before B is created
- [x] `bun run typecheck` passes
- [x] `bun run check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the extra delete prompt shown on exit after choosing Keep and finish. Clarified the post-create options and made Enter confirm Keep and finish. Fixes #129.

- **Bug Fixes**
  - Removed the session-level delete prompt and its flow after a successful keep; also removed the unused `askDeleteCreatedTokens` export.
  - Updated post-create action labels: “Keep and finish” (default), “Replace this key,” “Delete this key,” and “Keep and create another.”

<sup>Written for commit 0b786efbdac0f2327982e8d96f7d7c97d49b27c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant delete prompt and update post-create action labels in `create-cf-token`
> - Removes the end-of-session `deleteCreatedTokensFlow` prompt that previously asked users to delete any tokens created during a multi-token session.
> - Updates `askPostCreateAction` labels to "Keep and finish", "Replace this key", "Delete this key", and "Keep and create another", with a new default of "done".
> - Behavioral Change: the CLI no longer accumulates session tokens or prompts to bulk-delete them on exit; only the immediate post-create action applies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b786ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->