### PR TITLE
fix: sign Changesets version commits for verified-commit ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build Package
         run: bun run build
 
+      # commitMode: github-api pushes version bumps via the GitHub REST API so
+      # commits are GPG-signed by GitHub (verified). Required for repos with a
+      # required_signatures ruleset; git-cli commits from github-actions[bot] are unsigned.
       - name: Create Release Pull Request
         id: changesets
         if: github.ref == 'refs/heads/main'
@@ -57,6 +60,7 @@ jobs:
           version: bun changeset version
           commit: "chore: version packages"
           title: "chore: version packages"
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,10 @@ All matrix jobs must pass for a PR to be mergeable. Type-checking (`bun run type
 
 Releases are automated via [Changesets](https://github.com/changesets/changesets) and the `release.yml` workflow:
 
-1. Merging changesets to `main` triggers a "Version Packages" PR.
-2. Merging that PR publishes to npm with provenance and creates a GitHub release.
+1. Merging a PR with changeset files to `main` opens or updates a **chore: version packages** PR (`changeset-release/main`).
+2. Merge that PR into `main` with **Rebase and merge** so verified version commits satisfy the repository’s required-signatures ruleset.
+3. Publishing to npm and creating the GitHub release happens when `staging` is updated (see `release.yml`).
 
-You do not need to manually version or publish anything.
+Version bumps on the release branch use `commitMode: github-api` in the Changesets action so commits are GPG-signed by GitHub. Do not switch this back to the default `git-cli` mode — unsigned bot commits cannot merge into `main`.
+
+You do not need to manually run `changeset version` or publish to npm.


### PR DESCRIPTION
Closes #134

## Summary

- Set `commitMode: github-api` on the Changesets release action so version-bump commits on `changeset-release/main` are GPG-signed by GitHub (verified).
- Update `CONTRIBUTING.md` with the corrected release flow and merge guidance for the required-signatures ruleset.

Fixes blocked merges on release PRs (e.g. #103) where unsigned `github-actions[bot]` commits could not land on `main`. See #134.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Re-run the **Release** workflow (or push a noop commit) to refresh the version PR
- [ ] Confirm the version PR commit shows **Verified** on GitHub
- [ ] Merge the version PR with **Rebase and merge**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Signs Changesets version-bump commits via the GitHub API so release PRs show Verified and can merge under the required-signatures ruleset. Also updates the docs with the correct release flow and merge guidance.

- **Bug Fixes**
  - Set `commitMode: github-api` in `.github/workflows/release.yml` so version commits on `changeset-release/main` are GPG-signed by GitHub and pass required-signatures.
  - Updated `CONTRIBUTING.md` with the release flow: merge with Rebase and merge, publishing occurs when `staging` updates, and do not switch back to `git-cli`.

<sup>Written for commit 22574557151f157c40f9c5e092e53f86a32a4068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sign Changesets version commits via GitHub API to satisfy verified-commit ruleset
> Sets `commitMode: github-api` on the `Create Release Pull Request` step in [release.yml](.github/workflows/release.yml) so that Changesets creates version bump commits through the GitHub REST API rather than the git CLI, producing signed commits that satisfy branch protection rulesets requiring verified signatures. Updates [CONTRIBUTING.md](CONTRIBUTING.md) to reflect the new release flow, including the requirement to merge via "Rebase and merge" and a note not to revert `commitMode` back to `git-cli`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2257455.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->