### PR TITLE
chore: simplify release workflow using changesets publish gating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,58 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    name: Release
+  version:
+    name: Version packages
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # commitMode: github-api pushes version bumps via the GitHub REST API so
+      # commits are GPG-signed by GitHub (verified). Required for repos with a
+      # required_signatures ruleset; git-cli commits from github-actions[bot] are unsigned.
+      - name: Create release pull request
+        id: changesets
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        with:
+          version: bun changeset version
+          commit: "chore: version packages"
+          title: "chore: version packages"
+          commitMode: github-api
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish release
+    needs: version
+    if: needs.version.outputs.has_changesets == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       id-token: write
-      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -39,6 +84,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
       - name: Update npm
@@ -50,23 +96,8 @@ jobs:
       - name: Build
         run: bun run build
 
-      # commitMode: github-api pushes version bumps via the GitHub REST API so
-      # commits are GPG-signed by GitHub (verified). Required for repos with a
-      # required_signatures ruleset; git-cli commits from github-actions[bot] are unsigned.
-      - name: Create release pull request
-        id: changesets
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
-        with:
-          version: bun changeset version
-          commit: "chore: version packages"
-          title: "chore: version packages"
-          commitMode: github-api
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Read package metadata
         id: package
-        if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           package_name=$(node --print "require('./package.json').name")
           package_version=$(node --print "require('./package.json').version")
@@ -76,14 +107,14 @@ jobs:
           echo "tag=v$package_version" >> "$GITHUB_OUTPUT"
 
       - name: Generate SBOM
-        if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           npm install --package-lock-only --ignore-scripts
           npm sbom --sbom-format cyclonedx --omit=dev > sbom.json
 
       - name: Publish package
         id: publish
-        if: steps.changesets.outputs.hasChangesets == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           package_name="${{ steps.package.outputs.name }}"
           package_version="${{ steps.package.outputs.version }}"
@@ -139,7 +170,7 @@ jobs:
           echo "staged=true" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
-        if: steps.changesets.outputs.hasChangesets == 'false' && (steps.publish.outputs.published == 'true' || steps.publish.outputs.staged == 'true')
+        if: steps.publish.outputs.published == 'true' || steps.publish.outputs.staged == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGE_VERSION: ${{ steps.package.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,24 @@ jobs:
             exit 0
           fi
 
-          staged_json=$(npm stage list "$package_name" --json 2>/dev/null || true)
-          if STAGED_JSON="$staged_json" PACKAGE_VERSION="$package_version" node --input-type=module <<'EOF'
+          stage_list_stderr=$(mktemp)
+          stage_list_status=0
+          staged_json=$(npm stage list "$package_name" --json 2>"$stage_list_stderr") || stage_list_status=$?
+
+          if [ "$stage_list_status" -ne 0 ]; then
+            if grep -qiE 'E401|E403|401|403|unauthorized|forbidden' "$stage_list_stderr"; then
+              cat "$stage_list_stderr" >&2
+              rm -f "$stage_list_stderr"
+              exit "$stage_list_status"
+            fi
+
+            echo "npm stage list unavailable; skipping staged-version preflight" >&2
+            cat "$stage_list_stderr" >&2
+            staged_json=""
+          fi
+          rm -f "$stage_list_stderr"
+
+          if [ -n "$staged_json" ] && STAGED_JSON="$staged_json" PACKAGE_VERSION="$package_version" node --input-type=module <<'EOF'
           const input = process.env.STAGED_JSON?.trim();
           if (!input) {
             process.exit(1);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - staging
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -18,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
       id-token: write
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -30,54 +29,32 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.14"
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
-      - name: Setup Node.js
+      - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
-          package-manager: npm
-          package-manager-version: "11.17.0"
           package-manager-cache: false
 
-      - name: Install Dependencies
+      - name: Update npm
+        run: npm install --global npm@latest
+
+      - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build Package
+      - name: Build
         run: bun run build
-
-      - name: Generate SBOM
-        if: github.ref == 'refs/heads/staging'
-        run: |
-          npx --yes npm@11.17.0 install --package-lock-only --ignore-scripts
-          npx --yes npm@11.17.0 sbom --sbom-format cyclonedx --omit=dev > sbom.json
-
-      - name: Upload SBOM artifact
-        if: github.ref == 'refs/heads/staging'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sbom
-          path: sbom.json
-          retention-days: 90
 
       # commitMode: github-api pushes version bumps via the GitHub REST API so
       # commits are GPG-signed by GitHub (verified). Required for repos with a
       # required_signatures ruleset; git-cli commits from github-actions[bot] are unsigned.
-      - name: Create Release Pull Request
+      - name: Create release pull request
         id: changesets
-        if: github.ref == 'refs/heads/main'
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bun changeset version
@@ -87,39 +64,108 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Stage Package Publish
-        if: github.ref == 'refs/heads/staging'
+      - name: Read package metadata
+        id: package
+        if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           package_name=$(node --print "require('./package.json').name")
-          version=$(node --print "require('./package.json').version")
+          package_version=$(node --print "require('./package.json').version")
 
-          if npx --yes npm@11.17.0 view "$package_name@$version" version >/dev/null 2>&1; then
-            echo "$package_name@$version is already published"
-            exit 0
-          fi
+          echo "name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$package_version" >> "$GITHUB_OUTPUT"
 
-          package_tarball=$(npx --yes npm@11.17.0 pack --ignore-scripts --silent)
-          npx --yes npm@11.17.0 stage publish "$package_tarball" --provenance --access public
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create GitHub Release
-        if: github.ref == 'refs/heads/staging'
+      - name: Generate SBOM
+        if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
-          version=$(node --print "require('./package.json').version")
-          tag="v$version"
+          npm install --package-lock-only --ignore-scripts
+          npm sbom --sbom-format cyclonedx --omit=dev > sbom.json
 
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "Release $tag already exists"
+      - name: Publish package
+        id: publish
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          package_name="${{ steps.package.outputs.name }}"
+          package_version="${{ steps.package.outputs.version }}"
+          package_spec="$package_name@$package_version"
+
+          if npm view "$package_spec" version >/dev/null 2>&1; then
+            echo "$package_spec is already published"
+            echo "published=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          awk -v version="$version" '
-            $0 == "## " version { printing = 1; next }
-            printing && /^## / { exit }
-            printing { print }
-          ' CHANGELOG.md > release-notes.md
+          staged_json=$(npm stage list "$package_name" --json 2>/dev/null || true)
+          if STAGED_JSON="$staged_json" PACKAGE_VERSION="$package_version" node --input-type=module <<'EOF'
+          const input = process.env.STAGED_JSON?.trim();
+          if (!input) {
+            process.exit(1);
+          }
 
-          gh release create "$tag" --target "$GITHUB_SHA" --title "$tag" --notes-file release-notes.md --latest sbom.json
+          let parsed;
+          try {
+            parsed = JSON.parse(input);
+          } catch {
+            process.exit(1);
+          }
+
+          if (parsed?.error) {
+            process.exit(1);
+          }
+
+          const version = process.env.PACKAGE_VERSION;
+          const staged = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
+          const hasVersion = staged.some((entry) => {
+            if (typeof entry === "string") {
+              return entry === version || entry.endsWith(`@${version}`);
+            }
+
+            if (!entry || typeof entry !== "object") {
+              return false;
+            }
+
+            return entry.version === version || entry.package?.version === version;
+          });
+
+          process.exit(hasVersion ? 0 : 1);
+          EOF
+          then
+            echo "$package_spec is already staged for approval"
+            echo "staged=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          npm stage publish . --access public --provenance
+          echo "staged=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.changesets.outputs.hasChangesets == 'false' && (steps.publish.outputs.published == 'true' || steps.publish.outputs.staged == 'true')
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          node --input-type=module <<'EOF' > release-notes.md
+          const fs = await import("node:fs/promises");
+          const changelog = await fs.readFile("CHANGELOG.md", "utf8");
+          const heading = `## ${process.env.PACKAGE_VERSION}`;
+          const start = changelog.indexOf(heading);
+          const bodyStart = start === -1 ? -1 : changelog.indexOf("\n", start) + 1;
+          const nextHeading = bodyStart === -1 ? -1 : changelog.indexOf("\n## ", bodyStart);
+          const notes = bodyStart === -1
+            ? `Release ${process.env.PACKAGE_VERSION}`
+            : changelog.slice(bodyStart, nextHeading === -1 ? undefined : nextHeading).trim();
+
+          console.log(notes);
+          EOF
+
+          if gh release view "${{ steps.package.outputs.tag }}" >/dev/null 2>&1; then
+            echo "GitHub release ${{ steps.package.outputs.tag }} already exists"
+            exit 0
+          fi
+
+          gh release create "${{ steps.package.outputs.tag }}" \
+            --target "$GITHUB_SHA" \
+            --title "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" \
+            --notes-file release-notes.md \
+            --latest \
+            sbom.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,26 +85,15 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager: npm
+          package-manager-version: "11.17.0"
           package-manager-cache: false
-
-      - name: Update npm
-        run: npm install --global npm@latest
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Build
         run: bun run build
-
-      - name: Read package metadata
-        id: package
-        run: |
-          package_name=$(node --print "require('./package.json').name")
-          package_version=$(node --print "require('./package.json').version")
-
-          echo "name=$package_name" >> "$GITHUB_OUTPUT"
-          echo "version=$package_version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$package_version" >> "$GITHUB_OUTPUT"
 
       - name: Generate SBOM
         run: |
@@ -116,8 +105,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          package_name="${{ steps.package.outputs.name }}"
-          package_version="${{ steps.package.outputs.version }}"
+          package_name=$(node --print "require('./package.json').name")
+          package_version=$(node --print "require('./package.json').version")
           package_spec="$package_name@$package_version"
 
           if npm view "$package_spec" version >/dev/null 2>&1; then
@@ -173,9 +162,12 @@ jobs:
         if: steps.publish.outputs.published == 'true' || steps.publish.outputs.staged == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
         run: |
-          node --input-type=module <<'EOF' > release-notes.md
+          package_name=$(node --print "require('./package.json').name")
+          package_version=$(node --print "require('./package.json').version")
+          tag="v$package_version"
+
+          PACKAGE_VERSION="$package_version" node --input-type=module <<'EOF' > release-notes.md
           const fs = await import("node:fs/promises");
           const changelog = await fs.readFile("CHANGELOG.md", "utf8");
           const heading = `## ${process.env.PACKAGE_VERSION}`;
@@ -189,14 +181,14 @@ jobs:
           console.log(notes);
           EOF
 
-          if gh release view "${{ steps.package.outputs.tag }}" >/dev/null 2>&1; then
-            echo "GitHub release ${{ steps.package.outputs.tag }} already exists"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "GitHub release $tag already exists"
             exit 0
           fi
 
-          gh release create "${{ steps.package.outputs.tag }}" \
+          gh release create "$tag" \
             --target "$GITHUB_SHA" \
-            --title "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" \
+            --title "$package_name@$package_version" \
             --notes-file release-notes.md \
             --latest \
             sbom.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Releases are automated via [Changesets](https://github.com/changesets/changesets
 
 1. Merging a PR with changeset files to `main` opens or updates a **chore: version packages** PR (`changeset-release/main`).
 2. Merge that PR into `main` with **Rebase and merge** so verified version commits satisfy the repository’s required-signatures ruleset.
-3. Publishing to npm and creating the GitHub release happens when `staging` is updated (see `release.yml`).
+3. Merging the version packages PR triggers `release.yml` again; with no pending changesets, the workflow stages the npm publish (with provenance) and creates the GitHub release.
 
 Version bumps on the release branch use `commitMode: github-api` in the Changesets action so commits are GPG-signed by GitHub. Do not switch this back to the default `git-cli` mode — unsigned bot commits cannot merge into `main`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Releases are automated via [Changesets](https://github.com/changesets/changesets
 
 1. Merging a PR with changeset files to `main` opens or updates a **chore: version packages** PR (`changeset-release/main`).
 2. Merge that PR into `main` with **Rebase and merge** so verified version commits satisfy the repository’s required-signatures ruleset.
-3. Merging the version packages PR triggers `release.yml` again; with no pending changesets, the workflow stages the npm publish (with provenance) and creates the GitHub release.
+3. Merging the version packages PR triggers `release.yml` again; with no pending changesets, the workflow stages the npm publish (with provenance) and creates the GitHub release. A maintainer must then approve the staged publish on [npmjs.com](https://www.npmjs.com/) (including 2FA) before the version is publicly installable.
 
 All release automation runs on `main` only. The legacy `staging` branch is no longer used; branch rulesets protect `main` (and `changeset-release/*` is excluded from required signatures). No ruleset changes are needed when removing a local `staging` branch.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,8 @@ Releases are automated via [Changesets](https://github.com/changesets/changesets
 2. Merge that PR into `main` with **Rebase and merge** so verified version commits satisfy the repository’s required-signatures ruleset.
 3. Merging the version packages PR triggers `release.yml` again; with no pending changesets, the workflow stages the npm publish (with provenance) and creates the GitHub release.
 
-Version bumps on the release branch use `commitMode: github-api` in the Changesets action so commits are GPG-signed by GitHub. Do not switch this back to the default `git-cli` mode — unsigned bot commits cannot merge into `main`.
+All release automation runs on `main` only. The legacy `staging` branch is no longer used; branch rulesets protect `main` (and `changeset-release/*` is excluded from required signatures). No ruleset changes are needed when removing a local `staging` branch.
+
+Version bumps on the version packages PR use `commitMode: github-api` in the Changesets action so commits are GPG-signed by GitHub. Do not switch this back to the default `git-cli` mode — unsigned bot commits cannot merge into `main`.
 
 You do not need to manually run `changeset version` or publish to npm.


### PR DESCRIPTION
## Summary

- Collapse the split `main` (changesets only) / `staging` (publish + release) flow into a single `main`-triggered workflow, matching the pattern in [codex-usage](https://github.com/mynameistito/codex-usage/blob/main/.github/workflows/release.yml)
- **Split into two jobs** for efficiency:
  - `version` — lightweight changesets-only path (no build) when opening/updating the version packages PR
  - `publish` — build, SBOM, npm stage, and GitHub release only when `hasChangesets == 'false'`
- Add idempotent publish logic: skip if already on npm, skip if already staged, otherwise `npm stage publish . --provenance`
- Keep repo-specific hardening: `harden-runner`, `commitMode: github-api` for GPG-signed version commits, CycloneDX SBOM on releases, `registry-url` for npm OIDC provenance, job timeouts
- Document `staging` branch retirement in `CONTRIBUTING.md`

### Staging / rulesets cleanup

- Verified GitHub rulesets only target `refs/heads/main` — **no ruleset changes required**
- Remote `staging` branch is already deleted
- Deleted stale local branches `staging` and `fix/release-staging-oidc`

## Test plan

- [ ] Actionlint passes on `.github/workflows/release.yml`
- [ ] Merge a changeset PR → verify **chore: version packages** PR opens (`version` job only; `publish` job skipped)
- [ ] Merge version packages PR → verify `publish` job stages npm publish with provenance and creates GitHub release with SBOM
- [ ] Re-run workflow on same commit → verify idempotent skip paths (already published / already staged / release exists)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify release workflow by splitting versioning and publish into separate gated jobs
> - Replaces the monolithic `release` job in [release.yml](.github/workflows/release.yml) with two jobs: `version` (creates/updates a version packages PR via changesets) and `publish` (builds, stages npm publish with provenance, and creates a GitHub release).
> - The `publish` job is gated on `has_changesets == 'false'`, so it only runs after the version packages PR is merged.
> - SBOM generation (`npm sbom` to CycloneDX) and GitHub release creation (with changelog notes) are now part of the `publish` job unconditionally, without branch-conditional logic.
> - Removes the staging branch from workflow triggers; all automation now runs on `main` only.
> - Updates [CONTRIBUTING.md](https://github.com/mynameistito/create-cf-token/pull/141/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) to reflect the new two-step release flow and note that maintainers must approve staged publishes on npmjs.com.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bd3478.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->