### PR TITLE
fix: keep help text module-private for JSR slow-type checks

### DIFF
--- a/.changeset/e6e58565.md
+++ b/.changeset/e6e58565.md
@@ -1,0 +1,5 @@
+---
+"create-cf-token": patch
+---
+
+Keep CLI help text module-private so JSR publish passes slow-type checks without exporting HELP_TEXT and AUTOMATION_HELP_TEXT from the public API.

--- a/src/help.ts
+++ b/src/help.ts
@@ -15,7 +15,7 @@ import colour from "#src/colour.ts";
 const NAME = "create-cf-token";
 const VERSION = process.env.npm_package_version ?? "0.0.0";
 
-export const HELP_TEXT = `
+const HELP_TEXT = `
   ${colour.WHITE}${NAME}${colour.RESET} ${colour.DIM}v${VERSION}${colour.RESET}
 
   A CLI tool for creating Cloudflare API tokens with interactive, guided prompts.
@@ -45,7 +45,7 @@ export const HELP_TEXT = `
   ${colour.DIM}https://github.com/mynameistito/create-cf-token${colour.RESET}
 `;
 
-export const AUTOMATION_HELP_TEXT = `
+const AUTOMATION_HELP_TEXT = `
   ${colour.WHITE}${NAME}${colour.RESET} ${colour.DIM}— automation${colour.RESET}
 
   Create Cloudflare API tokens without interactive prompts.

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,6 @@ import { parseCliArgs } from "#src/cli-args.ts";
 import colour from "#src/colour.ts";
 import type { CloudflareApiError } from "#src/errors.ts";
 import {
-  AUTOMATION_HELP_TEXT,
-  HELP_TEXT,
   printAutomationHelp,
   printHelp,
   printSkill,
@@ -145,8 +143,6 @@ export async function runAutomationIfNeeded(
 
   return false;
 }
-
-export { AUTOMATION_HELP_TEXT, HELP_TEXT };
 
 type ApiError = CloudflareApiError | UnhandledException;
 


### PR DESCRIPTION
## Summary

- Make `HELP_TEXT` and `AUTOMATION_HELP_TEXT` module-private in `help.ts` instead of exporting them with explicit type annotations
- Remove the unused re-export from `index.ts`
- Fixes JSR `missing-explicit-type` errors introduced in #142 without lint suppressions

## Test plan

- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `bunx jsr publish --dry-run`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `HELP_TEXT` and `AUTOMATION_HELP_TEXT` module-private in `help.ts` and remove their re-exports from `index.ts` to resolve JSR `missing-explicit-type` errors from #142 and avoid slow type checks. Add a changeset to publish this fix as a patch.

<sup>Written for commit b1365b9088fc3c53538bb5b38353dcfcec8d4017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove exports of `HELP_TEXT` and `AUTOMATION_HELP_TEXT` to satisfy JSR slow-type checks
> Makes `HELP_TEXT` and `AUTOMATION_HELP_TEXT` in [help.ts](https://github.com/mynameistito/create-cf-token/pull/143/files#diff-b6d686137f68270354ec92e4e1db41349a5b0445132d93169ad8059a177f543b) module-private by removing their `export` modifiers. The package entry point in [index.ts](https://github.com/mynameistito/create-cf-token/pull/143/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80) also drops the re-exports of these constants. Risk: any consumers importing these constants from the package will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1365b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->