### PR TITLE
docs: add and improve TSDoc across public API and internal modules

### DIFF
--- a/.changeset/d4e8b2f1-tsdoc.md
+++ b/.changeset/d4e8b2f1-tsdoc.md
@@ -1,0 +1,51 @@
+---
+"create-cf-token": patch
+---
+
+Add comprehensive TSDoc across the public API and internal modules so IDE tooltips, generated docs, and JSR type documentation accurately describe behaviour.
+
+**Consumer impact:** None for runtime behaviour, CLI flags, or published type shapes. This release improves developer experience for programmatic consumers (`create-cf-token`, subpath imports) and contributors working in `src/`.
+
+### Published library surface
+
+- **`index.ts`** — `@module` overview for the interactive orchestrator; documents `main()`, credential verification, session loop, and intentional re-exports (`buildPolicies`, CLI flag helpers)
+- **`api/client.ts`** — `@module api/client`; documents all Cloudflare REST wrappers (`getUser`, `getAccounts`, `getPermissionGroups`, `createToken`, `deleteToken`), internal helpers, pagination, and `Result` error mapping
+- **`automation/create.ts`** — `@module automation/create`; documents `createTokenFromSpec`, deps injection, error unions, and retry/exclusion semantics
+- **`automation/spec.ts`** — token spec parsing, normalization, and `TokenSpecError` conditions
+- **`automation/scope-spec.ts`** — scope/preset permission resolution and `ScopeSpecError` cases
+- **`policies/build.ts`** — `buildPolicies` inputs, account/resource scoping, and policy object shape
+- **`permissions/group.ts`** / **`permissions/resolve.ts`** — `groupByService`, `extractFailedPerm`, `resolveFullAccessPermissions`, and token-management exclusions
+- **`types/index.ts`** — documents shared interfaces (`Account`, `PermissionGroup`, `TokenPolicy`, `CreatedToken`, etc.)
+- **`errors/`** — module docs on `bases.ts` (full TaggedError hierarchy), class-level docs on all published error types, and `@link` cross-references between bases and thin exports
+
+### CLI & automation routing
+
+- **`cli/args.ts`** — `parseCliArgs`, `CliArgs`, non-interactive spec validation, and discovery command shapes
+- **`cli/flags.ts`** — `@module cli/flags`; `parseArgv`, `handleFlags`, `handleSkillFlag`, `runAutomationIfNeeded` with `@param` / `@returns` and early-exit semantics
+- **`cli/help.ts`** — help, version, automation help, and skill output entry points
+- **`cli/run.ts`** — deps-injectable `run()` orchestration (flags → skill → automation → `main()`)
+- **`automation/runner.ts`** — `shouldRunAutomation`, `runAutomationCreate`, `runDiscovery`, and non-interactive failure paths
+- **`automation/discovery.ts`** — `--discover` formatters for scopes, permissions, and accounts
+- **`automation/paths.ts`** — agent skill file paths and `readAutomationFile`
+- **`auth/template-url.ts`** — dashboard URL helpers for the interactive auth template flow
+
+### Interactive flow & prompts
+
+- **`flows/interactive-create.ts`** — `tokenCreateFlow`, `deleteTokens`, retry loop, and flow error types
+- **`prompts/types.ts`** — `GO_BACK`, prompt state, and search option types
+- **`prompts/guards.ts`** — `check()` cancellation guard and `exitIfNonInteractive()`
+- **`prompts/logging.ts`** — spinner, cancel, log, and outro helpers
+- **`prompts/flow/`** — documents each step (`credentials`, `preset`, `accounts`, `scopes`, `token-name`, `post-create`)
+- **`prompts/primitives/search-multiselect.ts`** — refactored inline types with TSDoc; documents back-navigation and `@clack/core` integration
+
+### Terminal helpers
+
+- **`terminal/colour.ts`**, **`terminal/hyperlink.ts`**, **`terminal/note.ts`** — ANSI colour tokens, OSC-8 hyperlinks, and boxed notes
+
+### Documentation conventions applied
+
+- `@module` tags on primary entry files for clear module boundaries in IDE outline views
+- Consistent `@param`, `@returns`, and `@throws` (where applicable) on exported functions
+- `{@linkcode …}` / `{@link …}` for cross-references between errors, bases, and public APIs
+- Internal interfaces and union error types documented alongside their owning exports
+- No logic, import graph, or export surface changes — comments only across **39 files** (~500 lines of documentation)

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -61,6 +61,13 @@ function tryParseJson<T>(text: string): T | null {
   }
 }
 
+/**
+ * Prefer structured Cloudflare `errors` messages; fall back to raw response text.
+ *
+ * @param text - Raw HTTP response body.
+ * @param errors - Optional `errors` array from a Cloudflare API envelope.
+ * @returns A single string suitable for error display.
+ */
 function formatApiErrorText(
   text: string,
   errors: { message?: string }[] | undefined
@@ -77,6 +84,10 @@ function formatApiErrorText(
 /**
  * Parse a Cloudflare API response body and extract `result` on success.
  *
+ * @param text - Raw HTTP response body.
+ * @param path - Request path (included in thrown {@linkcode CloudflareApiError}).
+ * @param res - Fetch `Response` (used for HTTP status when JSON parsing fails).
+ * @returns The unwrapped `result` field from a successful envelope.
  * @throws {CloudflareApiError} When the body is not JSON or `success` is false.
  */
 function parseCfResult<T>(text: string, path: string, res: Response): T {
@@ -112,6 +123,7 @@ interface DeleteTokenResponse {
   success: boolean;
 }
 
+/** Resolve the Cloudflare API v4 base URL, honouring `CF_API_BASE_URL` when set. */
 function cfApiBase(): string {
   const envVal = process.env.CF_API_BASE_URL;
   if (!envVal || envVal.trim() === "") {
@@ -124,6 +136,13 @@ function authHeaders(apiToken: string) {
   return { Authorization: `Bearer ${apiToken}` };
 }
 
+/**
+ * Authenticated GET against a Cloudflare API v4 path.
+ *
+ * @param path - Path appended to the API base (e.g. `/user`).
+ * @param apiToken - Bearer token sent in the `Authorization` header.
+ * @returns `Result<T, CloudflareApiError | UnhandledException>` with the parsed `result` on success.
+ */
 function cfGet<T>(
   path: string,
   apiToken: string
@@ -146,7 +165,12 @@ function cfGet<T>(
 /**
  * Fetch one page from a Cloudflare paginated list endpoint.
  *
- * @throws {CloudflareApiError} When the API returns `success: false`.
+ * @param basePath - List path without query string (e.g. `/accounts`).
+ * @param apiToken - Bearer token sent in the `Authorization` header.
+ * @param page - 1-based page number.
+ * @param perPage - Items per page (`per_page` query param).
+ * @returns The full list envelope including `result` and `result_info`.
+ * @throws {CloudflareApiError} When the body is not JSON or `success` is false.
  */
 async function fetchCfListPage<T>(
   basePath: string,
@@ -177,6 +201,15 @@ async function fetchCfListPage<T>(
 
 /**
  * Determine whether pagination should stop after the current page.
+ *
+ * Stops on an empty page, when `total_count` is reached, or when fewer items
+ * than `per_page` are returned.
+ *
+ * @param pageItems - Items from the page just fetched.
+ * @param info - Optional `result_info` from the list envelope.
+ * @param accumulatedCount - Total items collected so far (including this page).
+ * @param perPage - Requested page size used when `result_info.per_page` is absent.
+ * @returns `true` when no further pages should be fetched.
  */
 function isLastCfListPage<T>(
   pageItems: T[],
@@ -195,7 +228,14 @@ function isLastCfListPage<T>(
 }
 
 /**
- * Recursively fetch remaining pages from a Cloudflare paginated list endpoint.
+ * Recursively fetch all pages from a Cloudflare paginated list endpoint.
+ *
+ * @param basePath - List path without query string.
+ * @param apiToken - Bearer token sent in the `Authorization` header.
+ * @param page - Current 1-based page number.
+ * @param perPage - Items per page.
+ * @param accumulated - Items collected from prior pages.
+ * @returns Concatenated `result` arrays from every page.
  */
 async function fetchCfListPages<T>(
   basePath: string,
@@ -216,8 +256,12 @@ async function fetchCfListPages<T>(
 }
 
 /**
- * Internal helper for paginated GET list endpoints.
- * Fetches every page and concatenates `result` arrays.
+ * Authenticated GET for paginated list endpoints; fetches every page and concatenates `result` arrays.
+ *
+ * @param basePath - List path without query string.
+ * @param apiToken - Bearer token sent in the `Authorization` header.
+ * @param perPage - Items per page (defaults to 50).
+ * @returns `Result<T[], CloudflareApiError | UnhandledException>` with all items on success.
  */
 function cfGetPaginatedList<T>(
   basePath: string,
@@ -234,10 +278,10 @@ function cfGetPaginatedList<T>(
 }
 
 /**
- * Fetch the authenticated user's profile.
+ * Fetch the authenticated user's profile (`GET /user`).
  *
  * @param apiToken - Scoped Cloudflare API token.
- * @returns `Result<UserInfo, CloudflareApiError | UnhandledException>`
+ * @returns `Result<UserInfo, CloudflareApiError | UnhandledException>`.
  */
 export function getUser(
   apiToken: string
@@ -246,11 +290,12 @@ export function getUser(
 }
 
 /**
- * Fetch all accounts the authenticated user has access to.
+ * Fetch all accounts the authenticated user has access to (`GET /accounts`).
+ *
  * Paginates through the Cloudflare API until every page is retrieved.
  *
  * @param apiToken - Scoped Cloudflare API token.
- * @returns `Result<Account[], CloudflareApiError | UnhandledException>`
+ * @returns `Result<Account[], CloudflareApiError | UnhandledException>`.
  */
 export function getAccounts(
   apiToken: string
@@ -259,10 +304,10 @@ export function getAccounts(
 }
 
 /**
- * Fetch all available permission groups for API tokens.
+ * Fetch all assignable permission groups for API tokens (`GET /user/tokens/permission_groups`).
  *
  * @param apiToken - Scoped Cloudflare API token.
- * @returns `Result<PermissionGroup[], CloudflareApiError | UnhandledException>`
+ * @returns `Result<PermissionGroup[], CloudflareApiError | UnhandledException>`.
  */
 export function getPermissionGroups(
   apiToken: string
@@ -271,7 +316,10 @@ export function getPermissionGroups(
 }
 
 /**
- * Create a new Cloudflare user API token.
+ * Create a new Cloudflare user API token (`POST /user/tokens`).
+ *
+ * Maps restricted-permission API errors to {@linkcode RestrictedPermissionError}
+ * so callers can retry with exclusions.
  *
  * @param apiToken - Scoped token with `User API Tokens:Edit` permission.
  * @param name - Display name for the new token.
@@ -341,10 +389,10 @@ export function createToken(
 }
 
 /**
- * Delete (revoke) a Cloudflare API token by its ID.
+ * Delete (revoke) a Cloudflare user API token by ID (`DELETE /user/tokens/:id`).
  *
  * @param tokenId - The unique identifier of the token to delete.
- * @param apiToken - Scoped Cloudflare API token.
+ * @param apiToken - Scoped Cloudflare API token with permission to manage tokens.
  * @returns `Result<string, TokenDeletionError | UnhandledException>` — the deleted token's ID on success.
  */
 export function deleteToken(

--- a/src/auth/template-url.ts
+++ b/src/auth/template-url.ts
@@ -4,6 +4,12 @@ import type { PermissionGroup } from "@/types/index.ts";
 export const CF_API_TOKENS_URL =
   "https://dash.cloudflare.com/profile/api-tokens";
 
+/**
+ * Build a dashboard "Create Token" template URL from permission group keys.
+ *
+ * @param keys - Permission group keys and action types for the template query string.
+ * @returns A fully-formed dashboard URL with pre-filled template parameters.
+ */
 function buildAuthTemplateUrlFromKeys(
   keys: { key: string; type: string }[]
 ): string {
@@ -16,8 +22,11 @@ function buildAuthTemplateUrlFromKeys(
   return `${CF_API_TOKENS_URL}?${params.toString()}`;
 }
 
-/** Pre-built template URL to create the scoped auth token required by this tool.
- *  Keys are best-effort fallbacks — use {@linkcode buildAuthTemplateUrl} post-auth for accurate keys. */
+/**
+ * Pre-built template URL to create the scoped auth token required by this tool.
+ *
+ * Keys are best-effort fallbacks — use {@linkcode buildAuthTemplateUrl} post-auth for accurate keys.
+ */
 export const CF_AUTH_TEMPLATE_URL = buildAuthTemplateUrlFromKeys([
   { key: "user_details", type: "read" },
   { key: "api_tokens", type: "edit" },
@@ -29,6 +38,17 @@ const ACCOUNT_SCOPE = "com.cloudflare.api.account";
 const toLower = (s: string): string => s.toLowerCase();
 const hasKey = (permission: PermissionGroup): boolean => !!permission.key;
 
+/**
+ * Find a permission group by stable key, action suffix, and Cloudflare scope.
+ *
+ * Matches names ending in "read" for read actions, or "edit"/"write" for edit actions.
+ *
+ * @param perms - Permission groups from `/user/tokens/permission_groups`.
+ * @param permissionKey - Stable permission key (e.g. `user_details`, `api_tokens`).
+ * @param action - Required action level.
+ * @param scope - Cloudflare scope string (user or account).
+ * @returns The matching permission group, or `undefined` if none match.
+ */
 function findPermissionByKey(
   perms: PermissionGroup[],
   permissionKey: string,

--- a/src/automation/create.ts
+++ b/src/automation/create.ts
@@ -41,10 +41,13 @@ interface CreateTokenDeps {
 
 const defaultDeps: CreateTokenDeps = { createToken };
 
+/** Non-interactive create flow failure (invalid accounts, empty policies, retry exhaustion). */
 class CreateFlowError extends CreateFlowErrorBase {}
 
+/** Instance type of {@linkcode CreateFlowError}. */
 export type CreateFlowErrorType = InstanceType<typeof CreateFlowError>;
 
+/** Error union returned by {@linkcode createTokenFromSpec}. */
 export type CreateTokenFromSpecError =
   | CloudflareApiError
   | CreateFlowErrorType
@@ -54,17 +57,27 @@ export type CreateTokenFromSpecError =
   | TokenSpecErrorType
   | UnhandledException;
 
+/** Cloudflare API data required to resolve and create a token from a spec. */
 export interface CreateTokenContext {
+  /** Accounts visible to the bearer token (from {@linkcode getAccounts}). */
   accounts: Account[];
+  /** All assignable permission groups (from {@linkcode getPermissionGroups}). */
   allPerms: PermissionGroup[];
+  /** Bearer token used for the create request. */
   apiToken: string;
+  /** Service-level permission groupings (from {@linkcode groupByService}). */
   scopes: ServiceGroup[];
+  /** Authenticated user (from {@linkcode getUser}). */
   user: UserInfo;
 }
 
+/** Successful result of {@linkcode createTokenFromSpec}. */
 export interface CreateTokenFromSpecResult {
+  /** Permission names auto-excluded after {@linkcode RestrictedPermissionError} retries. */
   excludedPermissions: string[];
+  /** Resolved Cloudflare policy objects sent to (or previewed for) the API. */
   policies: TokenPolicy[];
+  /** Created token; omitted when `spec.dryRun` is true. */
   token?: CreatedToken;
 }
 
@@ -205,6 +218,16 @@ async function attemptCreateWithRetry(
 
 /**
  * Create a Cloudflare API token from a declarative spec without interactive prompts.
+ *
+ * Resolves accounts and permissions from `spec`, builds policies, and POSTs to the
+ * Cloudflare API. Retries up to 50 times, auto-excluding permissions that return
+ * {@linkcode RestrictedPermissionError}. When `spec.dryRun` is true, returns resolved
+ * policies without calling the API.
+ *
+ * @param spec - Parsed token specification (`preset`, `scopes`, `accounts`, etc.).
+ * @param context - Pre-fetched user, accounts, permissions, and bearer token.
+ * @param deps - Optional dependency overrides (primarily for tests).
+ * @returns A `Result` with policies and optional token on success; typed error on failure.
  */
 export function createTokenFromSpec(
   spec: TokenSpec,

--- a/src/automation/discovery.ts
+++ b/src/automation/discovery.ts
@@ -7,6 +7,7 @@
 import type { OutputFormat } from "@/cli/args.ts";
 import type { Account, PermissionGroup, ServiceGroup } from "@/types/index.ts";
 
+/** Scope list entry shape used in JSON discovery output. */
 interface ScopeListEntry {
   access: {
     other: PermissionGroup[];
@@ -29,6 +30,13 @@ function toScopeListEntry(service: ServiceGroup): ScopeListEntry {
   };
 }
 
+/**
+ * Format available service scopes for `--list-scopes` output.
+ *
+ * @param scopes - Service-level permission groupings.
+ * @param format - `"json"` for structured output, `"table"` for human-readable lines.
+ * @returns Formatted string with trailing newline.
+ */
 export function formatScopesList(
   scopes: ServiceGroup[],
   format: OutputFormat
@@ -58,6 +66,13 @@ export function formatScopesList(
   return `${lines.join("\n")}\n`;
 }
 
+/**
+ * Format all permission groups for `--list-permissions` output.
+ *
+ * @param permissions - All assignable permission groups from the Cloudflare API.
+ * @param format - `"json"` for structured output, `"table"` for tab-separated lines.
+ * @returns Formatted string with trailing newline.
+ */
 export function formatPermissionsList(
   permissions: PermissionGroup[],
   format: OutputFormat
@@ -76,6 +91,13 @@ export function formatPermissionsList(
   return `${lines.join("\n")}\n`;
 }
 
+/**
+ * Format accessible accounts for `--list-accounts` output.
+ *
+ * @param accounts - Accounts visible to the bearer token.
+ * @param format - `"json"` for structured output, `"table"` for tab-separated lines.
+ * @returns Formatted string with trailing newline.
+ */
 export function formatAccountsList(
   accounts: Account[],
   format: OutputFormat

--- a/src/automation/paths.ts
+++ b/src/automation/paths.ts
@@ -47,14 +47,30 @@ function getAutomationDir(): string {
   return resolveAutomationDir();
 }
 
+/** Resolve the absolute path to the packaged `skill.md` asset.
+ *
+ * @returns Absolute filesystem path to `skill.md`.
+ */
 export function getSkillPath(): string {
   return path.join(getAutomationDir(), SKILL_FILENAME);
 }
 
+/**
+ * Resolve the absolute path to a reference file under `references/`.
+ *
+ * @param filename - Basename of the reference file (e.g. `"scope-spec.md"`).
+ * @returns Absolute filesystem path to the reference file.
+ */
 export function getReferencePath(filename: string): string {
   return path.join(getAutomationDir(), REFERENCES_DIR, filename);
 }
 
+/**
+ * Read a packaged automation asset from disk.
+ *
+ * @param filePath - Absolute path returned by {@linkcode getSkillPath} or {@linkcode getReferencePath}.
+ * @returns File contents as UTF-8 text.
+ */
 export function readAutomationFile(filePath: string): Promise<string> {
   if (!existsSync(filePath)) {
     return Promise.reject(new Error(`Automation asset not found: ${filePath}`));

--- a/src/automation/runner.ts
+++ b/src/automation/runner.ts
@@ -142,6 +142,14 @@ function resolveTokenSpec(args: CliArgs): Promise<TokenSpec> {
   return Promise.resolve(cliArgsToTokenSpec(args));
 }
 
+/**
+ * Run a discovery command (`list-scopes`, `list-permissions`, or `list-accounts`).
+ *
+ * Prompts for credentials, fetches Cloudflare API data, and writes formatted output to stdout.
+ *
+ * @param args - Parsed CLI arguments including `command` and `format`.
+ * @param deps - Optional dependency overrides (primarily for tests).
+ */
 export async function runDiscovery(
   args: CliArgs,
   deps: AutomationRunnerDeps = defaultDeps
@@ -162,6 +170,16 @@ export async function runDiscovery(
   deps.writeStdout(formatAccountsList(context.accounts, args.format));
 }
 
+/**
+ * Run non-interactive token creation from CLI flags or a spec file.
+ *
+ * Validates args, resolves the token spec, creates the token via
+ * {@linkcode createTokenFromSpec}, and writes dry-run policies or the created token to stdout.
+ * Exits with code 1 on validation or API errors.
+ *
+ * @param args - Parsed CLI arguments (`name`, `scopes`, `file`, `dryRun`, etc.).
+ * @param deps - Optional dependency overrides (primarily for tests).
+ */
 export async function runAutomationCreate(
   args: CliArgs,
   deps: AutomationRunnerDeps = defaultDeps
@@ -234,6 +252,15 @@ export async function runAutomationCreate(
   }
 }
 
+/**
+ * Whether CLI args should take the automation path instead of the interactive flow.
+ *
+ * Returns true for discovery commands, explicit `create`, `--non-interactive`, or
+ * when enough automation flags are present with `-n`.
+ *
+ * @param args - Parsed CLI arguments.
+ * @returns `true` when automation routing should run.
+ */
 export function shouldRunAutomation(args: CliArgs): boolean {
   if (
     args.command === "list-scopes" ||
@@ -279,6 +306,14 @@ function isDiscoveryCommand(command: CliArgs["command"]): boolean {
   );
 }
 
+/**
+ * Fail fast when non-interactive mode is requested but the token spec is incomplete.
+ *
+ * Called before the interactive flow when stdin is not a TTY or `--non-interactive`
+ * is set. Exits with code 1 and usage guidance when validation fails.
+ *
+ * @param args - Parsed CLI arguments.
+ */
 export function failIfNonInteractiveIncomplete(args: CliArgs): void {
   if (process.stdin.isTTY === true) {
     if (args.explicitNonInteractive && !isDiscoveryCommand(args.command)) {

--- a/src/automation/scope-spec.ts
+++ b/src/automation/scope-spec.ts
@@ -12,8 +12,10 @@ import {
 } from "@/permissions/resolve.ts";
 import type { PermissionGroup, ServiceGroup } from "@/types/index.ts";
 
+/** Thrown when a scope spec string is invalid or references unknown services/permissions. */
 class ScopeSpecError extends ScopeSpecErrorBase {}
 
+/** Instance type of {@linkcode ScopeSpecError}. */
 export type ScopeSpecErrorType = InstanceType<typeof ScopeSpecError>;
 
 type AccessLevel = "read" | "write";
@@ -168,8 +170,16 @@ function resolveKeyLevelEntry(
 /**
  * Resolve a declarative scope spec string to concrete permission groups.
  *
- * Supports service+level (`Workers Scripts:write`), permission keys
- * (`workers_scripts:write`), and exact permission names (`"Workers Scripts Write"`).
+ * Supports three entry formats (comma-separated):
+ * - Service + level: `Workers Scripts:write`
+ * - Permission key + level: `workers_scripts:write`
+ * - Exact permission name: `"Workers Scripts Write"` (quote names containing commas)
+ *
+ * @param scopes - Service-level groupings from {@linkcode groupByService}.
+ * @param allPerms - All assignable permission groups from the Cloudflare API.
+ * @param spec - Comma-separated scope spec string.
+ * @returns Deduplicated permission groups matching the spec.
+ * @throws {ScopeSpecError} When the spec is empty, malformed, or references unknown entries.
  */
 export function resolvePermissionsFromScopeSpec(
   scopes: ServiceGroup[],
@@ -216,7 +226,12 @@ export function resolvePermissionsFromScopeSpec(
 }
 
 /**
- * Resolve permissions for a full-access preset (all scopes at read+write).
+ * Resolve permissions for the `full-access` preset (all scopes at read+write).
+ *
+ * Excludes API token management permissions via {@linkcode resolveFullAccessPermissions}.
+ *
+ * @param scopes - Service-level groupings from {@linkcode groupByService}.
+ * @returns All non–token-management permissions at read and write levels.
  */
 export function resolvePresetPermissions(
   scopes: ServiceGroup[]

--- a/src/automation/spec.ts
+++ b/src/automation/spec.ts
@@ -10,17 +10,30 @@ import { text as streamText } from "node:stream/consumers";
 
 import { TokenSpecErrorBase } from "@/errors/bases.ts";
 
+/** Thrown when token spec JSON is invalid or fails shape validation. */
 class TokenSpecError extends TokenSpecErrorBase {}
 
+/** Instance type of {@linkcode TokenSpecError}. */
 export type TokenSpecErrorType = InstanceType<typeof TokenSpecError>;
 
-/** Declarative token specification for non-interactive creation. */
+/**
+ * Declarative token specification for non-interactive creation.
+ *
+ * Requires either `preset: "full-access"` or a `scopes` string (not both).
+ * Scoped specs must include `accounts`.
+ */
 export interface TokenSpec {
+  /** Account IDs, `"all"`, or an array of IDs. Required when using `scopes`. */
   accounts?: string | string[];
+  /** When true, resolve policies only — do not POST to the API. */
   dryRun?: boolean;
+  /** Display name for the created token. */
   name: string;
+  /** CLI output format for the created token (ignored by the library create path). */
   output?: "json" | "text";
+  /** Grant all scopes at read+write, excluding API token management. */
   preset?: "full-access";
+  /** Comma-separated scope spec (see `create-cf-token/scope-spec`). */
   scopes?: string;
 }
 
@@ -135,7 +148,11 @@ function validateTokenSpecShape(spec: TokenSpec): void {
 }
 
 /**
- * Parse a token spec from a JSON string.
+ * Parse and validate a token spec from a JSON string.
+ *
+ * @param json - Raw JSON object with at least a `name` field and either `preset` or `scopes`.
+ * @returns A validated {@linkcode TokenSpec}.
+ * @throws {TokenSpecError} When JSON is malformed or fields fail validation.
  */
 export function parseTokenSpecJson(json: string): TokenSpec {
   let parsed: unknown;
@@ -166,7 +183,11 @@ export function parseTokenSpecJson(json: string): TokenSpec {
 }
 
 /**
- * Read a token spec from a file path or stdin (`-`).
+ * Read and parse a token spec from a file path or stdin.
+ *
+ * @param filePath - Filesystem path, or `"-"` to read from stdin.
+ * @returns A validated {@linkcode TokenSpec}.
+ * @throws {TokenSpecError} When the file is missing or contents fail validation.
  */
 export async function readTokenSpecFromFile(
   filePath: string
@@ -190,6 +211,9 @@ export async function readTokenSpecFromFile(
 
 /**
  * Normalize accounts from CLI args or token spec to a comma-separated string.
+ *
+ * @param accounts - A single account specifier, an array of IDs, or `undefined`.
+ * @returns Comma-separated account IDs, or `undefined` when input is absent.
  */
 export function normalizeAccountsInput(
   accounts: string | string[] | undefined

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,13 +1,15 @@
 /**
- * @module cli/args
+ * CLI argument parser and non-interactive validation for create-cf-token.
  *
- * CLI argument parser for create-cf-token.
+ * @module cli/args
  */
 
+/** Discovery and automation output format. */
 export type OutputFormat = "json" | "table";
 
 type OutputMode = "json" | "text";
 
+/** Parsed CLI state after argv processing. */
 export interface CliArgs {
   accounts?: string;
   command:
@@ -33,6 +35,7 @@ export interface CliArgs {
   yes: boolean;
 }
 
+/** Parse failure with a single human-readable message. */
 export interface CliParseError {
   error: string;
 }
@@ -312,9 +315,14 @@ function finalizeCommand(state: ParseState): void {
 }
 
 /**
- * Parse `process.argv` slice into structured CLI arguments.
+ * Parse an argv slice into structured CLI arguments.
  *
- * @param argv - Arguments after the node/bun script path.
+ * Defaults to interactive mode; infers `create` when non-interactive flags or env are set.
+ * Discovery commands (`--list-scopes`, etc.) and meta flags (`--help`, `--version`) are
+ * resolved to explicit `command` values.
+ *
+ * @param argv - Arguments after the node/bun script path (typically `process.argv.slice(2)`).
+ * @returns Parsed args, or {@link CliParseError} when an unknown flag or missing value is encountered.
  */
 export function parseCliArgs(argv: string[]): CliArgs | CliParseError {
   const state = createInitialState();
@@ -352,7 +360,10 @@ export function parseCliArgs(argv: string[]): CliArgs | CliParseError {
 }
 
 /**
- * Validate non-interactive requirements and return an actionable error message.
+ * Validate that non-interactive create args include a complete token spec.
+ *
+ * @param args - Parsed CLI arguments.
+ * @returns An error message when required fields are missing; `null` when the spec is complete.
  */
 export function validateNonInteractiveSpec(args: CliArgs): string | null {
   if (args.file) {
@@ -379,7 +390,10 @@ export function validateNonInteractiveSpec(args: CliArgs): string | null {
 }
 
 /**
- * Whether the parsed args represent a complete non-interactive token spec.
+ * Whether parsed args represent a complete non-interactive token spec.
+ *
+ * @param args - Parsed CLI arguments.
+ * @returns `true` when {@link validateNonInteractiveSpec} returns no error.
  */
 export function hasCompleteTokenSpec(args: CliArgs): boolean {
   return validateNonInteractiveSpec(args) === null;

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -1,7 +1,9 @@
 /**
- * @module cli/flags
+ * CLI flag routing and early-exit handlers.
  *
- * CLI flag parsing and early-exit handlers.
+ * Bridges parsed argv to help output, skill printing, discovery, and automation create.
+ *
+ * @module cli/flags
  */
 
 import {
@@ -19,12 +21,28 @@ import {
   printVersion,
 } from "@/cli/help.ts";
 
+/** Result of parsing argv — either structured args or a parse error. */
 export type ParsedCli = CliArgs | CliParseError;
 
+/**
+ * Parse argv using {@link parseCliArgs}, defaulting to `process.argv.slice(2)`.
+ *
+ * @param argv - Arguments after the script path.
+ * @returns Parsed args or a {@link CliParseError}.
+ */
 export function parseArgv(argv: string[] = process.argv.slice(2)): ParsedCli {
   return parseCliArgs(argv);
 }
 
+/**
+ * Handle meta flags that exit immediately: help, automation help, and version.
+ *
+ * Parse errors print to stderr and exit with code 1. `--skill` is deferred to
+ * {@link handleSkillFlag} and returns `false` here.
+ *
+ * @param argv - Arguments after the script path.
+ * @returns `true` when a meta flag was handled (caller should not continue).
+ */
 export function handleFlags(argv: string[] = process.argv.slice(2)): boolean {
   const parsed = parseCliArgs(argv);
 
@@ -56,6 +74,12 @@ export function handleFlags(argv: string[] = process.argv.slice(2)): boolean {
   }
 }
 
+/**
+ * Print the bundled agent skill when `--skill` or `--help skill` was requested.
+ *
+ * @param argv - Arguments after the script path.
+ * @returns `true` when skill output was printed.
+ */
 export async function handleSkillFlag(
   argv: string[] = process.argv.slice(2)
 ): Promise<boolean> {
@@ -70,6 +94,15 @@ export async function handleSkillFlag(
   return false;
 }
 
+/**
+ * Run discovery or non-interactive automation when argv demands it.
+ *
+ * Handles `--list-scopes`, `--list-permissions`, `--list-accounts`, and `-n` create paths.
+ * Validates non-interactive specs before create; exits on parse or validation failure.
+ *
+ * @param argv - Arguments after the script path.
+ * @returns `true` when automation or discovery ran (caller should not start interactive flow).
+ */
 export async function runAutomationIfNeeded(
   argv: string[] = process.argv.slice(2)
 ): Promise<boolean> {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,7 +1,7 @@
 /**
- * @module cli/help
+ * CLI help text and agent skill output (`console.log` to stdout).
  *
- * CLI help text and agent skill output.
+ * @module cli/help
  */
 
 import {
@@ -128,14 +128,17 @@ export async function printSkill(): Promise<void> {
   console.log([...sections, ...referenceSections].join("\n"));
 }
 
+/** Print interactive usage and environment variable help. */
 export function printHelp(): void {
   console.log(HELP_TEXT);
 }
 
+/** Print non-interactive flags, scope spec formats, and examples. */
 export function printAutomationHelp(): void {
   console.log(AUTOMATION_HELP_TEXT);
 }
 
+/** Print the package version from `npm_package_version` or `0.0.0`. */
 export function printVersion(): void {
   console.log(VERSION);
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,7 +1,7 @@
 /**
- * @module cli/run
+ * CLI entry orchestration: early-exit flags, automation, skill output, interactive flow.
  *
- * CLI entry orchestration: flags, automation, and interactive flow.
+ * @module cli/run
  */
 
 import {
@@ -29,8 +29,13 @@ const defaultDeps: RunDeps = {
 };
 
 /**
- * Run the CLI. Checks for help/version flags first; if none are found,
- * starts the interactive token creation flow.
+ * Run the CLI entry pipeline.
+ *
+ * Order: help/version flags → `--skill` output → non-interactive automation → interactive {@link main}.
+ * Uncaught errors are routed through {@link handleCliError}.
+ *
+ * @param deps - Optional dependency overrides (primarily for tests).
+ * @returns Resolves when the selected path completes; process may exit early for flags.
  */
 export async function run(deps: RunDeps = defaultDeps): Promise<void> {
   try {

--- a/src/errors/bases.ts
+++ b/src/errors/bases.ts
@@ -1,7 +1,16 @@
 /**
  * @module errors/bases
  *
- * Internal TaggedError base classes shared across exported modules.
+ * Internal {@link https://github.com/supermacro/better-result | better-result} `TaggedErrorClass`
+ * factories. Each exported error file extends one base so `_tag` discrimination and `matchError`
+ * stay consistent across API, automation, and interactive flows.
+ *
+ * Hierarchy:
+ * - {@link CloudflareApiErrorBase} — generic REST envelope failures (any path).
+ * - {@link TokenCreationErrorBase} / {@link TokenDeletionErrorBase} — token lifecycle endpoints.
+ * - {@link RestrictedPermissionErrorBase} — restricted permission on create; callers retry with exclusions.
+ * - {@link ScopeSpecErrorBase} / {@link TokenSpecErrorBase} / {@link CreateFlowErrorBase} — automation spec parsing.
+ * - {@link TokenCreationFlowErrorBase} / {@link TokenDeletionFlowErrorBase} — interactive CLI flow failures.
  */
 
 import { TaggedError as createTaggedError } from "better-result";
@@ -13,6 +22,7 @@ interface CloudflareApiErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for HTTP / JSON envelope failures on Cloudflare REST paths. */
 export const CloudflareApiErrorBase: TaggedErrorClass<
   "CloudflareApiError",
   CloudflareApiErrorProps
@@ -23,6 +33,7 @@ interface TokenCreationErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for non-restricted failures from `POST /user/tokens`. */
 export const TokenCreationErrorBase: TaggedErrorClass<
   "TokenCreationError",
   TokenCreationErrorProps
@@ -33,6 +44,7 @@ interface TokenDeletionErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for failures from `DELETE /user/tokens/:id`. */
 export const TokenDeletionErrorBase: TaggedErrorClass<
   "TokenDeletionError",
   TokenDeletionErrorProps
@@ -44,6 +56,7 @@ interface RestrictedPermissionErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for restricted-permission rejections on token create; carries `permissionName` for retry exclusion. */
 export const RestrictedPermissionErrorBase: TaggedErrorClass<
   "RestrictedPermissionError",
   RestrictedPermissionErrorProps
@@ -55,6 +68,7 @@ interface ScopeSpecErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for invalid scope-spec JSON in automation (`create-cf-token/scope-spec`). */
 export const ScopeSpecErrorBase: TaggedErrorClass<
   "ScopeSpecError",
   ScopeSpecErrorProps
@@ -64,6 +78,7 @@ interface TokenSpecErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for invalid token-spec JSON in automation (`create-cf-token/spec`). */
 export const TokenSpecErrorBase: TaggedErrorClass<
   "TokenSpecError",
   TokenSpecErrorProps
@@ -73,6 +88,7 @@ interface CreateFlowErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for non-interactive create failures in automation (`create-cf-token/create`). */
 export const CreateFlowErrorBase: TaggedErrorClass<
   "CreateFlowError",
   CreateFlowErrorProps
@@ -82,6 +98,7 @@ interface TokenCreationFlowErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for terminal failures in the interactive token-create flow. */
 export const TokenCreationFlowErrorBase: TaggedErrorClass<
   "TokenCreationFlowError",
   TokenCreationFlowErrorProps
@@ -91,6 +108,7 @@ interface TokenDeletionFlowErrorProps extends Record<string, unknown> {
   message: string;
 }
 
+/** Base for terminal failures in the interactive token-delete flow. */
 export const TokenDeletionFlowErrorBase: TaggedErrorClass<
   "TokenDeletionFlowError",
   TokenDeletionFlowErrorProps

--- a/src/errors/cloudflare-api-error.ts
+++ b/src/errors/cloudflare-api-error.ts
@@ -1,5 +1,6 @@
 import { CloudflareApiErrorBase } from "@/errors/bases.ts";
 
+/** Error returned when a Cloudflare REST request fails (non-OK HTTP, invalid JSON, or `success: false`). */
 export class CloudflareApiError extends CloudflareApiErrorBase {
   constructor(args: { path: string; messages: string[] }) {
     super({

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,7 +1,8 @@
 /**
  * @module errors
  *
- * Cloudflare API error types for create-cf-token.
+ * Published API error types for `create-cf-token/errors`. Returned as `Result` errors from
+ * the API client — never thrown at library boundaries.
  */
 
 export { CloudflareApiError } from "@/errors/cloudflare-api-error.ts";

--- a/src/errors/restricted-permission-error.ts
+++ b/src/errors/restricted-permission-error.ts
@@ -1,5 +1,9 @@
 import { RestrictedPermissionErrorBase } from "@/errors/bases.ts";
 
+/**
+ * Error returned when `POST /user/tokens` rejects a permission the caller cannot grant.
+ * Interactive flows add `permissionName` to an exclusion set and retry (up to 50 attempts).
+ */
 export class RestrictedPermissionError extends RestrictedPermissionErrorBase {
   constructor(args: { permissionName: string; errorText: string }) {
     super({

--- a/src/errors/token-creation-error.ts
+++ b/src/errors/token-creation-error.ts
@@ -1,5 +1,9 @@
 import { TokenCreationErrorBase } from "@/errors/bases.ts";
 
+/**
+ * Error returned when `POST /user/tokens` fails for a reason other than a restricted permission
+ * (those map to {@link RestrictedPermissionError} instead).
+ */
 export class TokenCreationError extends TokenCreationErrorBase {
   constructor(args: { errorText: string }) {
     super({

--- a/src/errors/token-creation-flow-error.ts
+++ b/src/errors/token-creation-flow-error.ts
@@ -1,3 +1,4 @@
 import { TokenCreationFlowErrorBase } from "@/errors/bases.ts";
 
+/** Terminal failure in the interactive token-create flow (not published from `create-cf-token/errors`). */
 export class TokenCreationFlowError extends TokenCreationFlowErrorBase {}

--- a/src/errors/token-deletion-error.ts
+++ b/src/errors/token-deletion-error.ts
@@ -1,5 +1,6 @@
 import { TokenDeletionErrorBase } from "@/errors/bases.ts";
 
+/** Error returned when `DELETE /user/tokens/:id` fails. */
 export class TokenDeletionError extends TokenDeletionErrorBase {
   constructor(args: { errorText: string }) {
     super({

--- a/src/errors/token-deletion-flow-error.ts
+++ b/src/errors/token-deletion-flow-error.ts
@@ -1,3 +1,4 @@
 import { TokenDeletionFlowErrorBase } from "@/errors/bases.ts";
 
+/** Terminal failure in the interactive token-delete flow (not published from `create-cf-token/errors`). */
 export class TokenDeletionFlowError extends TokenDeletionFlowErrorBase {}

--- a/src/flows/interactive-create.ts
+++ b/src/flows/interactive-create.ts
@@ -1,7 +1,7 @@
 /**
- * @module flows/interactive-create
+ * Interactive token creation, restricted-permission retry, and deletion flow.
  *
- * Interactive token creation, retry, and deletion flow.
+ * @module flows/interactive-create
  */
 
 import { matchError } from "better-result";
@@ -181,6 +181,15 @@ async function deleteTokenAtIndex(
   return deleteTokenAtIndex(tokensToDelete, apiToken, s, deps, index + 1);
 }
 
+/**
+ * Delete one or more created tokens sequentially with spinner feedback.
+ *
+ * @param tokensToDelete - Tokens to revoke via the Cloudflare API.
+ * @param apiToken - Parent API token with delete permission.
+ * @param s - Spinner instance for progress messages.
+ * @param deps - Optional dependency overrides (primarily for tests).
+ * @throws {@link TokenDeletionFlowError} When any delete request fails.
+ */
 export async function deleteTokens(
   tokensToDelete: CreatedToken[],
   apiToken: string,
@@ -200,6 +209,21 @@ export async function deleteTokens(
   );
 }
 
+/**
+ * Run one interactive token-creation pass: preset, accounts, scopes, name, then create.
+ *
+ * Retries up to 50 times when the API reports restricted permissions, auto-excluding
+ * them on each attempt. Supports `GO_BACK` navigation to restart inner prompt steps.
+ *
+ * @param accounts - Cloudflare accounts available to the parent token.
+ * @param scopes - Permission groups grouped by service for scope selection.
+ * @param userId - Authenticated user ID for user-scoped policies.
+ * @param apiToken - Parent API token used to create the new token.
+ * @param s - Spinner instance for progress messages.
+ * @param deps - Optional dependency overrides (primarily for tests).
+ * @returns The newly created token metadata and secret value.
+ * @throws {@link TokenCreationFlowError} When creation fails after retries or policy build yields nothing.
+ */
 export async function tokenCreateFlow(
   accounts: Account[],
   scopes: ServiceGroup[],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 /**
- * @module index
+ * Interactive CLI orchestrator for create-cf-token.
  *
- * CLI orchestrator for the create-cf-token tool.
+ * Verifies credentials, fetches accounts and permission groups, then runs the
+ * interactive token-creation session loop. Re-exports policy and CLI flag helpers
+ * for the published library surface.
+ *
+ * @module index
  */
 
 import { isCancel } from "@clack/prompts";
@@ -78,6 +82,12 @@ const defaultDeps: IndexDeps = {
   tokenCreateFlow,
 };
 
+/**
+ * Map a Cloudflare API or unhandled error to a user-facing cancel message and exit.
+ *
+ * @param error - API failure or unexpected exception from credential verification or fetch calls.
+ * @param deps - Optional dependency overrides (primarily for tests).
+ */
 export function handleApiError(
   error: ApiError,
   deps: IndexDeps = defaultDeps
@@ -93,6 +103,11 @@ export function handleApiError(
   process.exit(1);
 }
 
+/**
+ * Handle top-level CLI failures: silent exit on prompt cancel, otherwise log and exit 1.
+ *
+ * @param err - Thrown value from the interactive flow or orchestrator.
+ */
 export function handleCliError(err: unknown): never {
   if (isCancel(err)) {
     process.exit(0);
@@ -159,6 +174,15 @@ async function runCreateSession(
   /* eslint-enable no-await-in-loop */
 }
 
+/**
+ * Run the full interactive token-creation session.
+ *
+ * Prompts for credentials, verifies the parent token, loads accounts and scopes,
+ * then delegates to {@link tokenCreateFlow} in a post-create loop until the user exits.
+ *
+ * @param deps - Optional dependency overrides (primarily for tests).
+ * @returns Resolves when the user finishes or a flow error sets a non-zero exit code.
+ */
 export async function main(deps: IndexDeps = defaultDeps): Promise<void> {
   deps.printNote(
     [

--- a/src/permissions/group.ts
+++ b/src/permissions/group.ts
@@ -214,6 +214,7 @@ function extractFailedPermFromSource(source: string): string | null {
  *
  * @param permissionName - Full permission group name from the Cloudflare API.
  * @param excluded - Permission or service names to omit.
+ * @returns `true` when the permission or its service base name is in `excluded`.
  */
 export function isPermissionExcluded(
   permissionName: string,
@@ -228,6 +229,9 @@ export function isPermissionExcluded(
 
 /**
  * Permission names to pre-exclude for token-management groups (sub-tokens cannot grant these).
+ *
+ * @param perms - All available permission groups from the Cloudflare API.
+ * @returns Set of permission names under the {@link TOKEN_MANAGEMENT_SERVICE} service.
  */
 export function buildTokenManagementExclusions(
   perms: PermissionGroup[]
@@ -244,6 +248,14 @@ export function buildTokenManagementExclusions(
   return excluded;
 }
 
+/**
+ * Parse a restricted permission name from Cloudflare token-create error text.
+ *
+ * Handles `permission group:` markers, quoted values, and the sub-token management message.
+ *
+ * @param errorText - Raw API error body or message list from `POST /user/tokens`.
+ * @returns Matched permission or service name, or `null` when none is found.
+ */
 export function extractFailedPerm(
   errorText: readonly string[] | string
 ): string | null {

--- a/src/permissions/resolve.ts
+++ b/src/permissions/resolve.ts
@@ -1,6 +1,7 @@
 import { TOKEN_MANAGEMENT_SERVICE } from "@/permissions/group.ts";
 import type { PermissionGroup, ServiceGroup } from "@/types/index.ts";
 
+/** Read-only vs read+write selection for services that expose both permission groups. */
 export type AccessLevel = "read" | "write";
 
 /**
@@ -8,6 +9,7 @@ export type AccessLevel = "read" | "write";
  *
  * @param scopes - All available service groups.
  * @param selected - Names of scopes the user checked in the multi-select.
+ * @returns `true` when every service group name is present in `selected`.
  */
 export function isAllScopesSelected(
   scopes: ServiceGroup[],
@@ -27,6 +29,10 @@ export function isAllScopesSelected(
 
 /**
  * Whether a single bulk access-level prompt should replace per-service prompts.
+ *
+ * @param scopes - All available service groups.
+ * @param selected - Names of scopes the user checked in the multi-select.
+ * @returns `true` when all scopes are selected and at least one has both read and write permissions.
  */
 export function shouldUseBulkAccessLevel(
   scopes: ServiceGroup[],

--- a/src/policies/build.ts
+++ b/src/policies/build.ts
@@ -7,6 +7,18 @@
 import { isPermissionExcluded } from "@/permissions/group.ts";
 import type { Account, PermissionGroup, TokenPolicy } from "@/types/index.ts";
 
+/**
+ * Build Cloudflare API token policies from selected permission groups.
+ *
+ * Buckets permissions by scope (user, account, zone), omits names in `excluded`, and emits
+ * one `allow` policy per scope that has matching permissions and required resources.
+ *
+ * @param perms - Permission groups chosen for the token.
+ * @param userId - Authenticated user ID for user-scoped resource URIs.
+ * @param accounts - Accounts used for account- and zone-scoped resource URIs.
+ * @param excluded - Permission or service base names to skip (retry after restricted-permission errors).
+ * @returns Policy objects ready for `POST /user/tokens`.
+ */
 export function buildPolicies(
   perms: PermissionGroup[],
   userId: string,

--- a/src/prompts/flow/accounts.ts
+++ b/src/prompts/flow/accounts.ts
@@ -13,8 +13,11 @@ const defaultDeps: SelectAccountsDeps = { searchMultiselect };
 /**
  * Prompt the user to select one or more Cloudflare accounts from the given list.
  *
+ * Backspace with an empty search field returns {@linkcode GO_BACK}.
+ *
  * @param accounts - Accounts fetched from the Cloudflare API.
- * @returns The accounts the user selected.
+ * @param deps - Injectable prompt primitives (defaults to production {@linkcode searchMultiselect}).
+ * @returns Selected accounts, or {@linkcode GO_BACK} when the user navigates back.
  */
 export async function selectAccounts(
   accounts: Account[],

--- a/src/prompts/flow/credentials.ts
+++ b/src/prompts/flow/credentials.ts
@@ -15,7 +15,7 @@ function isPlaceholderToken(value: string): boolean {
  *
  * The token needs at minimum: User Details:Read, User API Tokens:Edit, Account Settings:Read.
  *
- * @returns The collected API token.
+ * @returns An object containing the trimmed API token string.
  */
 export async function askCredentials(): Promise<{ apiToken: string }> {
   const envToken = process.env.CF_API_TOKEN;

--- a/src/prompts/flow/post-create.ts
+++ b/src/prompts/flow/post-create.ts
@@ -5,6 +5,14 @@ import { check, exitIfNonInteractive } from "@/prompts/guards.ts";
 import type { PostCreateAction } from "@/prompts/types.ts";
 import colour from "@/terminal/colour.ts";
 
+/**
+ * Ask what to do with a token that was just created.
+ *
+ * Options include keeping it, replacing it (revoke + recreate), deleting it,
+ * or keeping it and starting another create flow.
+ *
+ * @returns The chosen post-create action.
+ */
 export async function askPostCreateAction(): Promise<PostCreateAction> {
   exitIfNonInteractive();
   return check(

--- a/src/prompts/flow/preset.ts
+++ b/src/prompts/flow/preset.ts
@@ -6,6 +6,8 @@ import type { TokenPreset } from "@/prompts/types.ts";
 /**
  * Ask whether to create a full-access token or choose accounts and scopes manually.
  *
+ * Exits the process on Ctrl+C or Escape via {@linkcode check}.
+ *
  * @returns `"full-access"` for all accounts with every scope at read + write, or `"custom"`.
  */
 export async function askTokenPreset(): Promise<TokenPreset> {

--- a/src/prompts/flow/scopes.ts
+++ b/src/prompts/flow/scopes.ts
@@ -160,7 +160,7 @@ async function pickScopesAndBuildPermissions(
  * during the access-level sub-prompt, they return to the scope selection.
  *
  * @param scopes - All available service groups.
- * @returns The chosen permission groups, or {@linkcode GO_BACK}.
+ * @returns The chosen permission groups, or {@linkcode GO_BACK} when the user navigates back.
  */
 export function selectScopes(
   scopes: ServiceGroup[]

--- a/src/prompts/flow/token-name.ts
+++ b/src/prompts/flow/token-name.ts
@@ -6,8 +6,11 @@ const defaultDeps = { textWithBack };
 /**
  * Prompt the user to enter a token name, pre-filled with a generated default.
  *
+ * Backspace on an empty input returns {@linkcode GO_BACK}.
+ *
  * @param defaultName - The initial value shown in the input field.
- * @returns The entered name, or {@link module:prompts/types.GO_BACK} on Backspace.
+ * @param deps - Injectable prompt primitives (defaults to production {@linkcode textWithBack}).
+ * @returns The entered name, or {@linkcode GO_BACK} when the user navigates back.
  */
 export function askTokenName(
   defaultName: string,

--- a/src/prompts/guards.ts
+++ b/src/prompts/guards.ts
@@ -1,6 +1,10 @@
 import { cancel, isCancel } from "@clack/prompts";
 
-/** Exit with failure instead of hanging when prompts cannot read from a terminal. */
+/**
+ * Abort when stdin is not a TTY so clack prompts do not hang in CI or piped input.
+ *
+ * Prints a cancellation message via clack and exits the process with code `1`.
+ */
 export function exitIfNonInteractive(): void {
   if (process.stdin.isTTY !== true) {
     cancel("Cancelled.");
@@ -15,6 +19,7 @@ export function exitIfNonInteractive(): void {
  * @template T - The expected value type.
  * @param value - The raw result from a clack prompt.
  * @returns The unwrapped value if not cancelled.
+ * @throws {symbol} The clack cancellation symbol after printing a cancellation message.
  */
 export function check<T>(value: T | symbol): T {
   if (isCancel(value)) {

--- a/src/prompts/logging.ts
+++ b/src/prompts/logging.ts
@@ -1,7 +1,9 @@
 import { cancel, log, outro, spinner } from "@clack/prompts";
 
 /**
- * Print a clack cancellation message and exit the process.
+ * Print a clack cancellation message without exiting the process.
+ *
+ * Callers typically follow up with their own exit or flow handling.
  *
  * @param message - The cancellation reason to display.
  */
@@ -9,7 +11,13 @@ export function cancelPrompt(message: string): void {
   cancel(message);
 }
 
-/** Thin wrapper around `@clack/prompts` log methods to avoid importing clack outside this module. */
+/**
+ * Clack log helpers — keeps `@clack/prompts` imports confined to this module.
+ *
+ * @property {function(string): void} error - Print an error-styled message.
+ * @property {function(string): void} info - Print an informational message.
+ * @property {function(string): void} warn - Print a warning-styled message.
+ */
 export const logMessage = {
   error: (message: string): void => log.error(message),
   info: (message: string): void => log.info(message),

--- a/src/prompts/primitives/search-multiselect.ts
+++ b/src/prompts/primitives/search-multiselect.ts
@@ -56,11 +56,27 @@ type SearchMultiselectPromptConstructor = new (config: {
 }) => SearchMultiselectPrompt;
 
 export interface SearchMultiselect {
+  /**
+   * Fuzzy-searchable multi-select with back-navigation enabled.
+   *
+   * @param message - The prompt question text.
+   * @param options - Available options to select from.
+   * @param allowBack - Must be `true` to enable Backspace-to-go-back.
+   * @returns Selected option values, or {@linkcode GO_BACK} when the user navigates back.
+   */
   (
     message: string,
     options: SearchOption[],
     allowBack: true
   ): Promise<Backable<string[]>>;
+  /**
+   * Fuzzy-searchable multi-select without back-navigation.
+   *
+   * @param message - The prompt question text.
+   * @param options - Available options to select from.
+   * @param allowBack - Must be `false` to omit back-navigation.
+   * @returns Selected option values.
+   */
   (
     message: string,
     options: SearchOption[],
@@ -70,10 +86,14 @@ export interface SearchMultiselect {
 
 /**
  * Whether a keypress should toggle select-all in a search multiselect.
- * Ctrl+A always toggles; bare `a` toggles only after the user navigated the option list.
  *
+ * Ctrl+A always toggles; bare `a` toggles only after the user navigated the option list.
  * Bare `a` cannot use `prompt.isNavigating` — AutocompletePrompt clears that flag
  * in its own key handler before custom listeners run.
+ *
+ * @param key - Normalised key metadata from clack.
+ * @param navigatingList - Whether the user has arrow-keyed into the option list.
+ * @returns `true` when the keypress should select or deselect all enabled options.
  */
 export function shouldToggleSelectAll(
   key: KeypressInfo | undefined,
@@ -106,16 +126,12 @@ function toggleSelectAll(prompt: SearchMultiselectPrompt): void {
 }
 
 /**
- * Show a fuzzy-searchable multi-select prompt with optional back-navigation.
+ * Factory for a {@linkcode SearchMultiselect} prompt backed by `@clack/core`.
  *
- * When `allowBack` is `true`, pressing Backspace with an empty search input
- * returns the {@linkcode GO_BACK} symbol instead of a value array.
+ * Accepts an optional prompt constructor override for unit tests.
  *
- * Overloaded: the return type narrows to `string[]` when `allowBack` is `false`.
- *
- * @param message - The prompt question text.
- * @param options - Available options to select from.
- * @param allowBack - Whether to enable back-navigation via Backspace.
+ * @param Prompt - AutocompletePrompt constructor (defaults to production clack).
+ * @returns A configured multiselect function with overloads for `allowBack`.
  */
 function createSearchMultiselect(
   Prompt: SearchMultiselectPromptConstructor = AutocompletePrompt as unknown as SearchMultiselectPromptConstructor

--- a/src/prompts/types.ts
+++ b/src/prompts/types.ts
@@ -1,4 +1,11 @@
 /**
+ * @module prompts/types
+ *
+ * Shared symbols and view-state types for the internal prompt layer.
+ * Used by flow steps, back-navigable primitives, and pure render helpers.
+ */
+
+/**
  * Unique symbol returned by backable prompts when the user presses Backspace
  * to go back to the previous prompt step.
  */

--- a/src/terminal/colour.ts
+++ b/src/terminal/colour.ts
@@ -1,7 +1,9 @@
 /**
- * @module terminal/colour
- *
  * ANSI escape code constants for terminal styling.
+ *
+ * Default export object — import as `import colour from "@/terminal/colour.ts"`.
+ *
+ * @module terminal/colour
  */
 const colour = {
   /** Bold cyan — URLs and interactive hints. */

--- a/src/terminal/hyperlink.ts
+++ b/src/terminal/hyperlink.ts
@@ -1,8 +1,15 @@
 /**
+ * OSC 8 terminal hyperlink helpers.
+ *
+ * @module terminal/hyperlink
+ */
+
+/**
  * Wrap a URL in an OSC 8 terminal hyperlink so it is clickable in supported terminals.
  * The visible text is the URL itself; the href target is also the full URL.
  *
  * @param url - The URL to link to and display.
+ * @returns The URL wrapped in OSC 8 open/close sequences.
  */
 export function hyperlinkUrl(url: string): string {
   return `\u001B]8;;${url}\u0007${url}\u001B]8;;\u0007`;

--- a/src/terminal/note.ts
+++ b/src/terminal/note.ts
@@ -1,3 +1,9 @@
+/**
+ * Bordered info boxes for terminal output with ANSI-aware wrapping.
+ *
+ * @module terminal/note
+ */
+
 import colour from "@/terminal/colour.ts";
 
 const ESCAPE_CHAR = String.fromCodePoint(27);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,14 +31,19 @@ export type TokenPolicyResourceValue = "*" | Record<string, "*">;
 
 /** A single policy entry for a Cloudflare user token. */
 export interface TokenPolicy {
+  /** Allow or deny the listed permission groups on the listed resources. */
   effect: "allow" | "deny";
+  /** Permission group IDs to grant or deny. */
   permission_groups: { id: string }[];
+  /** Cloudflare resource URIs mapped to `"*"` or zone-scoped wildcards. */
   resources: Record<string, TokenPolicyResourceValue>;
 }
 
 /** A created Cloudflare user token, as returned by POST /user/tokens. */
 export interface CreatedToken {
+  /** Token identifier used for deletion and dashboard links. */
   id: string;
+  /** Display name supplied at creation time. */
   name: string;
   /** The token secret — only present on creation, never returned again. */
   value: string;


### PR DESCRIPTION
## Summary

- Add and update TSDoc for exported functions, types, and error classes across 39 source files
- Prioritize published library entry points (api, create, spec, scope-spec, policies, permissions, types, errors)
- Document CLI orchestration (main, run, parseCliArgs), automation flows, and prompt layer exports
- Align existing docs with consistent @module, @param, @returns, and @throws tags

## Test plan

- [x] bun run typecheck
- [x] bun run check
- [x] Pre-commit hooks (ultracite fix + typecheck) passed on commit

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add and improve TSDoc across the public API, CLI, automation, errors, prompts, terminal helpers, policies/permissions, and types to deliver accurate IDE tooltips and consistent docs. Includes a patch-level changeset for `create-cf-token`; no runtime behavior or published type-shape changes.

<sup>Written for commit 61634f9754c0777a78311ada99c3f55fa992bf14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TSDoc comments across public API and internal modules
> Adds TSDoc to all public-facing types, interfaces, functions, and error classes across the codebase. No runtime behavior or API surface changes. Coverage spans API client, CLI args/flags, automation flows, error hierarchy, prompt primitives, and terminal utilities.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61634f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->