### PR TITLE
fix: format CHANGELOG.md after changeset version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          version: bun changeset version
+          version: bun run version-packages
           commit: "chore: version packages"
           title: "chore: version packages"
           commitMode: github-api

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -3,4 +3,7 @@ import ultracite from "ultracite/oxfmt";
 
 export default defineConfig({
   ...ultracite,
+  // Assembled by changesets from .changeset/*.md; nested markdown fails oxfmt
+  // rules that do not apply to the source changeset files (see PR #103).
+  ignorePatterns: [...(ultracite.ignorePatterns ?? []), "CHANGELOG.md"],
 });

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -3,7 +3,4 @@ import ultracite from "ultracite/oxfmt";
 
 export default defineConfig({
   ...ultracite,
-  // Assembled by changesets from .changeset/*.md; nested markdown fails oxfmt
-  // rules that do not apply to the source changeset files (see PR #103).
-  ignorePatterns: [...(ultracite.ignorePatterns ?? []), "CHANGELOG.md"],
 });

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "test:e2e:node": "bun run build && bun --config=./e2e.bunfig.toml test",
     "test:node": "bun run test:e2e:node",
     "typecheck": "tsgo --noEmit",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && bun run fix",
     "watch": "bun --watch src/cli.ts"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "test:e2e:node": "bun run build && bun --config=./e2e.bunfig.toml test",
     "test:node": "bun run test:e2e:node",
     "typecheck": "tsgo --noEmit",
-    "version-packages": "changeset version && bun run fix",
+    "version-packages": "changeset version && oxfmt CHANGELOG.md",
     "watch": "bun --watch src/cli.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

PR #103 failed only `ultracite check` on `CHANGELOG.md`.

**Why:** `@changesets/changelog-github` indents multi-line changeset bodies under list items. Blank lines in `.changeset/*.md` become whitespace-only indented lines; oxfmt rejects those after nested `###` headings. The same prose in a standalone changeset file passes — the failure is specific to assembled changelog structure.

**Fix:** `version-packages` runs `changeset version && oxfmt CHANGELOG.md`. This formats only the generated changelog (not `bun run fix` across the repo) and keeps `CHANGELOG.md` in the ultracite check scope.

`release.yml` already calls `bun run version-packages`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run check`
- [x] PR #103 `CHANGELOG.md` content passes `ultracite check` after `oxfmt CHANGELOG.md`
- [ ] Merge and confirm version packages PR passes `check` without manual edits

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format CHANGELOG.md automatically after running changeset version
> Adds `oxfmt CHANGELOG.md` to the `version-packages` script in [package.json](https://github.com/mynameistito/create-cf-token/pull/153/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) so the changelog is formatted after `changeset version` runs. Updates [release.yml](https://github.com/mynameistito/create-cf-token/pull/153/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) to invoke `bun run version-packages` instead of `bun changeset version` directly, so the formatting step is included in the release PR workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a09ed7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->