### PR TITLE
fix: deno.json version-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "test:e2e:node": "bun run build && bun --config=./e2e.bunfig.toml test",
     "test:node": "bun run test:e2e:node",
     "typecheck": "tsgo --noEmit",
-    "version-packages": "changeset version && oxfmt CHANGELOG.md && bun run sync-deno",
+    "version-packages": "changeset version && oxfmt CHANGELOG.md && oxfmt deno.json && bun run sync-deno",
     "watch": "bun --watch src/cli.ts"
   },
   "dependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated `version-packages` to format deno.json with `oxfmt` during versioning. This keeps the config consistent and prevents unnecessary diffs in CI.

<sup>Written for commit 78b45a705a4f2d461b460bbff0c98a58c7e0228f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `version-packages` script to format `deno.json` before syncing
> Adds `oxfmt deno.json` as a step in the `version-packages` npm script in [package.json](https://github.com/mynameistito/create-cf-token/pull/155/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), running it after formatting `CHANGELOG.md` and before `bun run sync-deno`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78b45a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->