### PR TITLE
fix: harden release version workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,9 @@ jobs:
   publish:
     name: Publish release
     needs: version
-    if: needs.version.outputs.has_changesets == 'false'
+    if: |
+      needs.version.outputs.has_changesets == 'false' &&
+      startsWith(github.event.head_commit.message, 'chore: version packages')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "test:e2e:node": "bun run build && bun --config=./e2e.bunfig.toml test",
     "test:node": "bun run test:e2e:node",
     "typecheck": "tsgo --noEmit",
-    "version-packages": "changeset version && ultracite fix ./CHANGELOG.md && ultracite fix ./deno.json && bun run sync-deno",
+    "version-packages": "changeset version && ultracite fix ./CHANGELOG.md && bun run sync-deno",
     "watch": "bun --watch src/cli.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes the release workflow failures after reverting a version-packages release commit.

- Removes the invalid `ultracite fix ./deno.json` step from `version-packages`; `sync-deno` already rewrites `deno.json` deterministically.
- Gates the publish job so it only runs for generated `chore: version packages` commits, preventing ordinary pushes with no changesets from entering the publish path.

## Validation

- `bun run check`