### PR TITLE
fix: use direct changelog formatter in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "test:e2e:node": "bun run build && bun --config=./e2e.bunfig.toml test",
     "test:node": "bun run test:e2e:node",
     "typecheck": "tsgo --noEmit",
-    "version-packages": "changeset version && ultracite fix ./CHANGELOG.md && bun run sync-deno",
+    "version-packages": "changeset version && oxfmt CHANGELOG.md && bun run sync-deno",
     "watch": "bun --watch src/cli.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes the remaining release workflow failure in `version-packages`.

- Replaces `ultracite fix ./CHANGELOG.md` with direct `oxfmt CHANGELOG.md` formatting.
- Avoids Ultracite's lint phase exiting with `No files found to lint` when only a Markdown file is targeted.

## Validation

- `bunx oxfmt CHANGELOG.md`
- `bun run check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `oxfmt` to format `CHANGELOG.md` in the `version-packages` release step, fixing the changelog formatting during versioning. Removes `ultracite fix`.

<sup>Written for commit e0bb2187d21ce621e704f1127101363217e5bb32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `ultracite fix` with `oxfmt` for CHANGELOG.md formatting in `version-packages` script
> The `version-packages` script in [package.json](https://github.com/mynameistito/create-cf-token/pull/161/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) now uses `oxfmt CHANGELOG.md` instead of `ultracite fix ./CHANGELOG.md` to format the changelog after running `changeset version`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0bb218.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->