### PR TITLE
chore: format deno.json with oxfmt in sync-deno

### DIFF
--- a/scripts/sync-deno.ts
+++ b/scripts/sync-deno.ts
@@ -3,6 +3,8 @@
  * Keep deno.json aligned with package.json for JSR publishes:
  * - `version`
  * - runtime `dependencies` as `npm:` import map entries
+ *
+ * deno.json is always written through `oxfmt` (same as version-packages).
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
@@ -21,6 +23,21 @@ interface DenoJson {
 const projectRoot = path.resolve(import.meta.dirname, "..");
 const packageJsonPath = path.join(projectRoot, "package.json");
 const denoJsonPath = path.join(projectRoot, "deno.json");
+
+function runOxfmt(): boolean {
+  const before = readFileSync(denoJsonPath, "utf-8");
+  const proc = Bun.spawnSync(["bun", "x", "oxfmt", denoJsonPath], {
+    cwd: projectRoot,
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+  if (proc.exitCode !== 0) {
+    process.exit(proc.exitCode ?? 1);
+  }
+
+  const after = readFileSync(denoJsonPath, "utf-8");
+  return before !== after;
+}
 
 const packageJson = JSON.parse(
   readFileSync(packageJsonPath, "utf-8")
@@ -47,19 +64,22 @@ const versionChanged = denoJson.version !== packageJson.version;
 
 if (!importsChanged && !versionChanged) {
   console.log("deno.json already in sync with package.json");
-  process.exit(0);
+} else {
+  if (versionChanged) {
+    denoJson.version = packageJson.version;
+    console.log(`Synced deno.json version to ${packageJson.version}`);
+  }
+
+  if (importsChanged) {
+    denoJson.imports = nextImports;
+    console.log(
+      `Synced deno.json npm imports from package.json dependencies (${Object.keys(npmImports).length})`
+    );
+  }
+
+  writeFileSync(denoJsonPath, `${JSON.stringify(denoJson)}\n`);
 }
 
-if (versionChanged) {
-  denoJson.version = packageJson.version;
-  console.log(`Synced deno.json version to ${packageJson.version}`);
+if (runOxfmt()) {
+  console.log("Formatted deno.json with oxfmt");
 }
-
-if (importsChanged) {
-  denoJson.imports = nextImports;
-  console.log(
-    `Synced deno.json npm imports from package.json dependencies (${Object.keys(npmImports).length})`
-  );
-}
-
-writeFileSync(denoJsonPath, `${JSON.stringify(denoJson, null, 2)}\n`);


### PR DESCRIPTION
## Summary

- Run `oxfmt` at the end of `sync-deno` so `deno.json` is always finalized with project formatting rules
- Aligns with `version-packages`, which already formats `CHANGELOG.md` via oxfmt before running sync-deno
- Formatting still runs when version/imports are already in sync, so manually edited `deno.json` files get normalized

## Test plan

- [x] `bun run sync-deno` on an in-sync `deno.json`
- [x] `bun run sync-deno` on an in-sync but unformatted `deno.json` (logs "Formatted deno.json with oxfmt")
- [x] `bun run typecheck`
- [x] `bun run check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `oxfmt` at the end of `sync-deno` so `deno.json` is always formatted and normalized, even when no sync changes are needed. Matches `version-packages` behavior.

- **New Features**
  - Always run `oxfmt` on `deno.json`; formatting runs even if version/imports are already in sync.
  - Propagate `oxfmt` failures and log "Formatted deno.json with oxfmt" when changes are applied.

<sup>Written for commit 312a4fedc714bfe6a95f41f47625dafef95eebac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format deno.json with oxfmt in sync-deno script
> - Updates [sync-deno.ts](https://github.com/mynameistito/create-cf-token/pull/173/files#diff-5865ba6c105a8ff65af600219b2db76260db16619b4868058a8f4d3f5426109c) to always run `oxfmt` on `deno.json` after any sync, rather than exiting early when no changes are detected.
> - Adds a `runOxfmt()` function that reads the file before and after formatting, exits with the formatter's non-zero code on failure, and returns whether the file changed.
> - The script now only writes `deno.json` when content changes are detected; the transient write uses minified JSON since `oxfmt` handles final formatting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 312a4fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->