### PR TITLE
fix: install npm 11.17 for staged publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       # npm stage requires CLI >= 11.15.0; setup-node does not pin npm version.
       - name: Upgrade npm
         run: |
-          npm install -g npm@11.17.0
+          npm install -g npm@latest
           npm --version
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,13 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          package-manager: npm
-          package-manager-version: "11.17.0"
           package-manager-cache: false
+
+      # npm stage requires CLI >= 11.15.0; setup-node does not pin npm version.
+      - name: Upgrade npm
+        run: |
+          npm install -g npm@11.17.0
+          npm --version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- The release workflow publish step failed with `Unknown command: "stage"` because CI was running npm 11.13.0 (bundled with Node 24).
- `npm stage` requires npm CLI >= 11.15.0 for staged publishing.
- `actions/setup-node@v6.4.0` does not support `package-manager` / `package-manager-version` inputs (they are silently ignored), so the intended npm 11.17.0 pin never took effect.
- Restores an explicit `npm install -g npm@11.17.0` step after setup-node.

Fixes failed run: https://github.com/mynameistito/create-cf-token/actions/runs/28129064885/job/83300452933

## Test plan

- [ ] Merge PR and re-run the release workflow (or workflow_dispatch) on a version-packages commit
- [ ] Confirm Setup Node logs show npm 11.17.0 after the upgrade step
- [ ] Confirm `npm stage publish` succeeds and the package is staged for maintainer approval

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the release workflow by explicitly installing `npm@11.17.0` so `npm stage publish` works. CI was using npm 11.13.0 with Node 24, which lacks `stage` and broke publishes.

- **Bug Fixes**
  - Add a step to install `npm@11.17.0` after `actions/setup-node@v6.4.0` and verify with `npm --version`.
  - Remove unsupported `package-manager` inputs from `setup-node` (v6 ignores them).

<sup>Written for commit bafd08b252674703a256b31c33e01212a82f9ff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install npm 11.17 explicitly in the release workflow staged publish step
> The `setup-node` action does not reliably pin the npm version, so the release workflow now runs a dedicated "Upgrade npm" step that installs npm globally and echoes its version. The `package-manager` and `package-manager-version` inputs are removed from the `setup-node` step in [release.yml](.github/workflows/release.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9b0d3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->