### PR TITLE
fix: allow manual release publish retry via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      publish_release:
+        description: Retry publish for the current package.json version (e.g. after a failed publish)
+        type: boolean
+        default: false
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -60,8 +65,10 @@ jobs:
     name: Publish release
     needs: version
     if: |
-      needs.version.outputs.has_changesets == 'false' &&
-      startsWith(github.event.head_commit.message, 'chore: version packages')
+      needs.version.outputs.has_changesets == 'false' && (
+        startsWith(github.event.head_commit.message, 'chore: version packages') ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish_release == true)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Summary

- **Do not restore the deleted changesets from #163** — that commit already consumed them into `CHANGELOG.md` and bumped `package.json` to `1.2.0`. Re-adding them would open another version PR and try to version again.
- Publish was skipped after merging #174 because the publish job only runs when the commit message starts with `chore: version packages` (by design, from #159).
- Adds a `publish_release` workflow_dispatch input so maintainers can retry staging/publishing the current version after a failed publish, without a fake version-packages commit.

## How to publish 1.2.0 after merge

1. Go to Actions → Release → Run workflow
2. Check **publish_release**
3. Run on `main`

The workflow will stage `create-cf-token@1.2.0` (if not already published/staged), publish to JSR, and create the GitHub release.

## Test plan

- [ ] Merge PR
- [ ] Run Release workflow on `main` with `publish_release` enabled
- [ ] Confirm publish job runs and `npm stage publish` succeeds

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual publish retry to the Release workflow. Maintainers can re-run staging/publish for the current package.json version via workflow_dispatch without creating a fake version commit.

- **New Features**
  - Added `publish_release` boolean input to the `Release` workflow.
  - Publish job now runs when either:
    - The commit message starts with "chore: version packages", or
    - The workflow is manually triggered with `publish_release` enabled, and there are no pending changesets.
  - To retry: Actions → Release → Run workflow on `main` with `publish_release` checked.

<sup>Written for commit d65b08233a7fa46ba16265701a489b817764fbc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

