### PR TITLE
fix: use npm OIDC trusted publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,11 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
       # npm stage requires CLI >= 11.15.0; setup-node does not pin npm version.
+      # Do not set registry-url on setup-node — it writes _authToken=${NODE_AUTH_TOKEN}
+      # to .npmrc and blocks npm Trusted Publishing (OIDC).
       - name: Upgrade npm
         run: |
           npm install -g npm@latest
@@ -134,14 +135,13 @@ jobs:
           staged_json=$(npm stage list "$package_name" --json 2>"$stage_list_stderr") || stage_list_status=$?
 
           if [ "$stage_list_status" -ne 0 ]; then
+            # npm stage list cannot use OIDC; auth failures are expected without a token.
             if grep -qiE 'E401|E403|401|403|unauthorized|forbidden' "$stage_list_stderr"; then
+              echo "npm stage list requires interactive auth; skipping staged-version preflight" >&2
+            else
+              echo "npm stage list unavailable; skipping staged-version preflight" >&2
               cat "$stage_list_stderr" >&2
-              rm -f "$stage_list_stderr"
-              exit "$stage_list_status"
             fi
-
-            echo "npm stage list unavailable; skipping staged-version preflight" >&2
-            cat "$stage_list_stderr" >&2
             staged_json=""
           fi
           rm -f "$stage_list_stderr"
@@ -185,11 +185,13 @@ jobs:
             exit 0
           fi
 
+          unset NODE_AUTH_TOKEN
           npm stage publish . --access public --provenance
           echo "staged=true" >> "$GITHUB_OUTPUT"
 
-      # OIDC auth (id-token: write above) — no JSR_TOKEN secret required when the
-      # package is linked to this repo in JSR package settings.
+      # npm Trusted Publishing (OIDC): id-token write above; no NPM_TOKEN secret.
+      # Ensure the package trusted publisher on npmjs.com allows npm stage publish
+      # for workflow file release.yml in this repository.
       - name: Publish to JSR
         run: bunx jsr publish
 


### PR DESCRIPTION
## Summary

The publish job now fails with `E401` because `setup-node` `registry-url` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`. With no `NPM_TOKEN` secret, npm substitutes `GITHUB_TOKEN` and tries classic bearer auth instead of GitHub OIDC trusted publishing.

- Remove `registry-url` from `setup-node` so OIDC can engage (`id-token: write` is already set)
- `unset NODE_AUTH_TOKEN` immediately before `npm stage publish`
- Treat `npm stage list` auth failures as optional preflight skips (that command cannot use OIDC)

Fixes: https://github.com/mynameistito/create-cf-token/actions/runs/28129810404/job/83302970928

## npm trusted publisher checklist (manual)

On https://www.npmjs.com/package/create-cf-token/access ensure trusted publishing is configured for:
- Repository: `mynameistito/create-cf-token`
- Workflow file: `release.yml`
- Allowed action: **npm stage publish** (not just `npm publish`)

## Test plan

- [ ] Merge PR
- [ ] Run Release workflow on `main` with `publish_release` checked
- [ ] Confirm `npm stage publish` succeeds (stages `create-cf-token@1.2.0`)
- [ ] Approve staged publish on npmjs.com

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the release workflow to npm Trusted Publishing (OIDC) so `npm stage publish` authenticates via GitHub OIDC, fixing `E401` errors and removing the need for `NPM_TOKEN`.

- **Bug Fixes**
  - Remove `registry-url` from `actions/setup-node` to avoid writing `_authToken` to `.npmrc`.
  - `unset NODE_AUTH_TOKEN` before `npm stage publish`.
  - Treat `npm stage list` auth failures as non-fatal and skip the preflight (it can’t use OIDC).

- **Migration**
  - In npm package “Access,” enable Trusted Publishing for repo `mynameistito/create-cf-token` and workflow `release.yml`.
  - Allow action `npm stage publish` in the trusted publisher settings.

<sup>Written for commit 2eb78d604022e902c310f5bb5b8a949c248e4c16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch npm release workflow to OIDC trusted publishing
> - Removes `registry-url` from the `setup-node` step to prevent `_authToken` being written to `.npmrc`, and unsets `NODE_AUTH_TOKEN` before `npm stage publish` so authentication relies solely on OIDC.
> - Changes `npm stage list` failure handling: auth errors (401/403/unauthorized/forbidden) now log a skip message and continue rather than exiting, so the preflight check no longer blocks the release on auth failures.
> - Behavioral Change: the workflow no longer exits on `npm stage list` failures; it proceeds with an empty staged version list instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2eb78d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->