### PR TITLE
fix: run JSR publish before generating SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,11 +110,6 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Generate SBOM
-        run: |
-          npm install --package-lock-only --ignore-scripts
-          npm sbom --sbom-format cyclonedx --omit=dev > sbom.json
-
       - name: Publish package
         id: publish
         env:
@@ -194,6 +189,11 @@ jobs:
       # for workflow file release.yml in this repository.
       - name: Publish to JSR
         run: bunx jsr publish
+
+      - name: Generate SBOM
+        run: |
+          npm install --package-lock-only --ignore-scripts
+          npm sbom --sbom-format cyclonedx --omit=dev > sbom.json
 
       - name: Create GitHub release
         if: steps.publish.outputs.published == 'true' || steps.publish.outputs.staged == 'true'


### PR DESCRIPTION
## Summary

- JSR publish failed because `Generate SBOM` ran first and left untracked `sbom.json` in the working tree.
- `deno publish` (via `bunx jsr publish`) aborts on uncommitted changes unless `--allow-dirty` is passed.
- Reorder release steps: npm stage publish -> JSR publish -> generate SBOM -> GitHub release.

The SBOM is only needed as a GitHub release attachment, so generating it after JSR publish keeps the tree clean without relaxing JSR publish checks.

## Test plan

- [ ] Merge and re-run Release workflow with `publish_release`
- [ ] Confirm `bunx jsr publish` succeeds on a clean tree
- [ ] Confirm GitHub release still attaches `sbom.json`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the release workflow to run `bunx jsr publish` before generating the SBOM, fixing publish failures caused by an untracked `sbom.json`. This keeps the git tree clean and still attaches the SBOM to the GitHub release.

- **Bug Fixes**
  - Run `bunx jsr publish` before SBOM generation.
  - Avoid `deno publish` aborts on uncommitted changes without `--allow-dirty`.
  - Generate SBOM after publish; GitHub release still includes `sbom.json`.

<sup>Written for commit 2199cb6cadca448d3cfe2fbf1c836acd3e3e93a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move SBOM generation to after JSR publish in release workflow
> Reorders the 'Generate SBOM' step in [release.yml](.github/workflows/release.yml) to run after 'Publish to JSR' instead of before 'Publish package', ensuring `sbom.json` reflects the published package state before being uploaded in the GitHub release step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2199cb6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->