### PR TITLE
chore: extract release workflow logic into TypeScript scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,19 +90,15 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      # npm stage requires CLI >= 11.15.0. Do not set registry-url on setup-node —
+      # it writes _authToken=${NODE_AUTH_TOKEN} to .npmrc and blocks OIDC publishing.
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+          package-manager: npm
+          package-manager-version: "11.17.0"
           package-manager-cache: false
-
-      # npm stage requires CLI >= 11.15.0; setup-node does not pin npm version.
-      # Do not set registry-url on setup-node — it writes _authToken=${NODE_AUTH_TOKEN}
-      # to .npmrc and blocks npm Trusted Publishing (OIDC).
-      - name: Upgrade npm
-        run: |
-          npm install -g npm@latest
-          npm --version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -111,121 +107,12 @@ jobs:
         run: bun run build
 
       - name: Publish package
-        id: publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          package_name=$(node --print "require('./package.json').name")
-          package_version=$(node --print "require('./package.json').version")
-          package_spec="$package_name@$package_version"
+        run: bun run ./scripts/release-publish-npm.ts
 
-          if npm view "$package_spec" version >/dev/null 2>&1; then
-            echo "$package_spec is already published"
-            echo "published=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          stage_list_stderr=$(mktemp)
-          stage_list_status=0
-          staged_json=$(npm stage list "$package_name" --json 2>"$stage_list_stderr") || stage_list_status=$?
-
-          if [ "$stage_list_status" -ne 0 ]; then
-            # npm stage list cannot use OIDC; auth failures are expected without a token.
-            if grep -qiE 'E401|E403|401|403|unauthorized|forbidden' "$stage_list_stderr"; then
-              echo "npm stage list requires interactive auth; skipping staged-version preflight" >&2
-            else
-              echo "npm stage list unavailable; skipping staged-version preflight" >&2
-              cat "$stage_list_stderr" >&2
-            fi
-            staged_json=""
-          fi
-          rm -f "$stage_list_stderr"
-
-          if [ -n "$staged_json" ] && STAGED_JSON="$staged_json" PACKAGE_VERSION="$package_version" node --input-type=module <<'EOF'
-          const input = process.env.STAGED_JSON?.trim();
-          if (!input) {
-            process.exit(1);
-          }
-
-          let parsed;
-          try {
-            parsed = JSON.parse(input);
-          } catch {
-            process.exit(1);
-          }
-
-          if (parsed?.error) {
-            process.exit(1);
-          }
-
-          const version = process.env.PACKAGE_VERSION;
-          const staged = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
-          const hasVersion = staged.some((entry) => {
-            if (typeof entry === "string") {
-              return entry === version || entry.endsWith(`@${version}`);
-            }
-
-            if (!entry || typeof entry !== "object") {
-              return false;
-            }
-
-            return entry.version === version || entry.package?.version === version;
-          });
-
-          process.exit(hasVersion ? 0 : 1);
-          EOF
-          then
-            echo "$package_spec is already staged for approval"
-            echo "staged=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          unset NODE_AUTH_TOKEN
-          npm stage publish . --access public --provenance
-          echo "staged=true" >> "$GITHUB_OUTPUT"
-
-      # npm Trusted Publishing (OIDC): id-token write above; no NPM_TOKEN secret.
-      # Ensure the package trusted publisher on npmjs.com allows npm stage publish
-      # for workflow file release.yml in this repository.
       - name: Publish to JSR
-        run: bunx jsr publish
-
-      - name: Generate SBOM
-        run: |
-          npm install --package-lock-only --ignore-scripts
-          npm sbom --sbom-format cyclonedx --omit=dev > sbom.json
+        run: bun run jsr:publish
 
       - name: Create GitHub release
-        if: steps.publish.outputs.published == 'true' || steps.publish.outputs.staged == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          package_name=$(node --print "require('./package.json').name")
-          package_version=$(node --print "require('./package.json').version")
-          tag="v$package_version"
-
-          PACKAGE_VERSION="$package_version" node --input-type=module <<'EOF' > release-notes.md
-          const fs = await import("node:fs/promises");
-          const changelog = await fs.readFile("CHANGELOG.md", "utf8");
-          const heading = `## ${process.env.PACKAGE_VERSION}`;
-          const start = changelog.indexOf(heading);
-          const bodyStart = start === -1 ? -1 : changelog.indexOf("\n", start) + 1;
-          const nextHeading = bodyStart === -1 ? -1 : changelog.indexOf("\n## ", bodyStart);
-          const notes = bodyStart === -1
-            ? `Release ${process.env.PACKAGE_VERSION}`
-            : changelog.slice(bodyStart, nextHeading === -1 ? undefined : nextHeading).trim();
-
-          console.log(notes);
-          EOF
-
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "GitHub release $tag already exists"
-            exit 0
-          fi
-
-          gh release create "$tag" \
-            --target "$GITHUB_SHA" \
-            --title "$package_name@$package_version" \
-            --notes-file release-notes.md \
-            --latest \
-            sbom.json
+        run: bun run ./scripts/release-github.ts

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "prepublishOnly": "bun run build && bun run sync-skill",
     "deno:dry-run": "deno task dry-run",
     "jsr:dry-run": "bunx jsr publish --dry-run",
+    "jsr:publish": "bunx jsr publish",
     "release": "bun run build && changeset publish --provenance",
     "test:security": "bun run build && bun test __tests__/security.test.ts",
     "start": "bun src/cli.ts",

--- a/scripts/release-github.ts
+++ b/scripts/release-github.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+/**
+ * Generate an SBOM and create a GitHub release for the current package.json version.
+ *
+ * Used by `.github/workflows/release.yml`. Requires `gh`, npm, `GITHUB_SHA`, and
+ * `GH_TOKEN` (or `GITHUB_TOKEN`, which `gh` also accepts).
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+interface PackageJson {
+  name: string;
+  version: string;
+}
+
+const projectRoot = path.resolve(import.meta.dirname, "..");
+const packageJsonPath = path.join(projectRoot, "package.json");
+const changelogPath = path.join(projectRoot, "CHANGELOG.md");
+const sbomPath = path.join(projectRoot, "sbom.json");
+const notesPath = path.join(projectRoot, "release-notes.md");
+
+function readPackageJson(): PackageJson {
+  return JSON.parse(readFileSync(packageJsonPath, "utf-8")) as PackageJson;
+}
+
+function extractReleaseNotes(version: string): string {
+  const changelog = readFileSync(changelogPath, "utf-8");
+  const heading = `## ${version}`;
+  const start = changelog.indexOf(heading);
+
+  if (start === -1) {
+    return `Release ${version}`;
+  }
+
+  const bodyStart = changelog.indexOf("\n", start) + 1;
+  const nextHeading = changelog.indexOf("\n## ", bodyStart);
+
+  return changelog
+    .slice(bodyStart, nextHeading === -1 ? undefined : nextHeading)
+    .trim();
+}
+
+function run(command: string[], options?: { captureStdout?: boolean }): string {
+  const proc = Bun.spawnSync(command, {
+    cwd: projectRoot,
+    env: process.env,
+    stderr: "inherit",
+    stdout: options?.captureStdout ? "pipe" : "inherit",
+  });
+
+  if ((proc.exitCode ?? 1) !== 0) {
+    process.exit(proc.exitCode ?? 1);
+  }
+
+  return options?.captureStdout ? (proc.stdout?.toString() ?? "") : "";
+}
+
+function generateSbom(): void {
+  run(["npm", "install", "--package-lock-only", "--ignore-scripts"]);
+  writeFileSync(
+    sbomPath,
+    run(["npm", "sbom", "--sbom-format", "cyclonedx", "--omit=dev"], {
+      captureStdout: true,
+    })
+  );
+}
+
+function createGitHubRelease(): void {
+  const { name, version } = readPackageJson();
+  const tag = `v${version}`;
+  const target = process.env.GITHUB_SHA;
+
+  if (!target) {
+    console.error("GITHUB_SHA is required");
+    process.exit(1);
+  }
+
+  writeFileSync(notesPath, extractReleaseNotes(version));
+
+  const existing = Bun.spawnSync(["gh", "release", "view", tag], {
+    cwd: projectRoot,
+    env: process.env,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  if (existing.exitCode === 0) {
+    console.log(`GitHub release ${tag} already exists`);
+    return;
+  }
+
+  run([
+    "gh",
+    "release",
+    "create",
+    tag,
+    "--target",
+    target,
+    "--title",
+    `${name}@${version}`,
+    "--notes-file",
+    notesPath,
+    "--latest",
+    sbomPath,
+  ]);
+}
+
+generateSbom();
+createGitHubRelease();

--- a/scripts/release-publish-npm.ts
+++ b/scripts/release-publish-npm.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env bun
+/**
+ * Stage an npm release via OIDC trusted publishing (`npm stage publish`).
+ *
+ * Used by `.github/workflows/release.yml`. Requires npm >= 11.15 and no
+ * `registry-url` / `_authToken` in `.npmrc` (OIDC trusted publishing).
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+interface PackageJson {
+  name: string;
+  version: string;
+}
+
+const projectRoot = path.resolve(import.meta.dirname, "..");
+const packageJsonPath = path.join(projectRoot, "package.json");
+
+function npmEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.NODE_AUTH_TOKEN;
+  return env;
+}
+
+const packageJson = JSON.parse(
+  readFileSync(packageJsonPath, "utf-8")
+) as PackageJson;
+const packageSpec = `${packageJson.name}@${packageJson.version}`;
+
+const view = Bun.spawnSync(["npm", "view", packageSpec, "version"], {
+  cwd: projectRoot,
+  env: npmEnv(),
+  stderr: "pipe",
+  stdout: "pipe",
+});
+
+if (view.exitCode === 0) {
+  console.log(`${packageSpec} is already published`);
+  process.exit(0);
+}
+
+const stage = Bun.spawnSync(
+  ["npm", "stage", "publish", ".", "--access", "public", "--provenance"],
+  {
+    cwd: projectRoot,
+    env: npmEnv(),
+    stderr: "pipe",
+    stdout: "inherit",
+  }
+);
+
+const stageStderr = stage.stderr.toString();
+
+if (stage.exitCode === 0) {
+  process.exit(0);
+}
+
+if (/E409|409|already staged|already exists|duplicate/iu.test(stageStderr)) {
+  console.error(`${packageSpec} is already staged for approval`);
+  console.error(stageStderr);
+  process.exit(0);
+}
+
+console.error(stageStderr);
+process.exit(stage.exitCode ?? 1);


### PR DESCRIPTION
## Summary

- Move npm staging, SBOM generation, and GitHub release creation from inline YAML shell into \scripts/release-publish-npm.ts\ and \scripts/release-github.ts\`n- Remove dead \
pm stage list\ preflight (cannot authenticate with OIDC trusted publishing)
- Pin npm 11.17 via \setup-node\ instead of a separate global upgrade step
- Add \jsr:publish\ package script alias (mirrors \jsr:dry-run\ in CI)

## Test plan

- [ ] CI passes on the PR
- [ ] \un run typecheck\ and \un run check\ pass locally
- [ ] On next release, publish job stages npm package via OIDC and creates GitHub release with SBOM

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted release workflow logic into TypeScript scripts to simplify CI and make releases consistent. The new flow stages the `npm` package via OIDC, generates a CycloneDX SBOM, and creates the GitHub release.

- **Refactors**
  - Replaced inline shell in `./github/workflows/release.yml` with `scripts/release-publish-npm.ts` and `scripts/release-github.ts`.
  - Removed the broken `npm stage list` preflight and added a `jsr:publish` script used by CI.

- **Dependencies**
  - Pinned `npm@11.17.0` via `actions/setup-node` to support `npm stage` without a separate upgrade step.

<sup>Written for commit 4e02231d536056344bc6125de71cf5bf8adf8b78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mynameistito/create-cf-token/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

